### PR TITLE
[OPENSSL] Upgrade to OpenSSL 1.1 and make it compilable on windows.

### DIFF
--- a/Source/cryptography/Cryptography.cpp
+++ b/Source/cryptography/Cryptography.cpp
@@ -167,14 +167,14 @@ namespace Implementation {
             }
 
         public:
-            uint32_t Encrypt(const uint8_t ivLength, const uint8_t iv[],
+            int32_t Encrypt(const uint8_t ivLength, const uint8_t iv[],
                             const uint32_t inputLength, const uint8_t input[],
                             const uint32_t maxOutputLength, uint8_t output[]) const override
             {
                 return (cipher_encrypt(_implementation, ivLength, iv, inputLength, input, maxOutputLength, output));
             }
 
-            uint32_t Decrypt(const uint8_t ivLength, const uint8_t iv[],
+            int32_t Decrypt(const uint8_t ivLength, const uint8_t iv[],
                             const uint32_t inputLength, const uint8_t input[],
                             const uint32_t maxOutputLength, uint8_t output[]) const override
             {

--- a/Source/cryptography/Cryptography.vcxproj
+++ b/Source/cryptography/Cryptography.vcxproj
@@ -1,0 +1,210 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="cryptography.h" />
+    <ClInclude Include="ICryptography.h" />
+    <ClInclude Include="implementation\OpenSSL\Derive.h" />
+    <ClInclude Include="implementation\OpenSSL\Vault.h" />
+    <ClInclude Include="INetflixSecurity.h" />
+    <ClInclude Include="Module.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="Cryptography.cpp" />
+    <ClCompile Include="implementation\OpenSSL\Cipher.cpp" />
+    <ClCompile Include="implementation\OpenSSL\Derive.cpp" />
+    <ClCompile Include="implementation\OpenSSL\DiffieHellman.cpp" />
+    <ClCompile Include="implementation\OpenSSL\Hash.cpp" />
+    <ClCompile Include="implementation\OpenSSL\Vault.cpp" />
+    <ClCompile Include="NetflixSecurity.cpp" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>16.0</VCProjectVersion>
+    <ProjectGuid>{38D878FD-FAAD-4620-B1AF-5CB4AB5385F2}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>Cryptography</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <ProjectName>cryptography</ProjectName>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(SolutionDir)..\artifacts\$(Configuration)\</OutDir>
+    <IntDir>$(OutDir)Thunder\$(TargetName)\</IntDir>
+    <TargetName>$(ProjectName)</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(SolutionDir)..\artifacts\$(Configuration)\</OutDir>
+    <IntDir>$(OutDir)Thunder\$(TargetName)\</IntDir>
+    <TargetName>$(ProjectName)</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(SolutionDir)..\artifacts\$(Configuration)\</OutDir>
+    <IntDir>$(OutDir)Thunder\$(TargetName)\</IntDir>
+    <TargetName>$(ProjectName)</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(SolutionDir)..\artifacts\$(Configuration)\</OutDir>
+    <IntDir>$(OutDir)Thunder\$(TargetName)\</IntDir>
+    <TargetName>$(ProjectName)</TargetName>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>DISPLAYINFO_EXPORTS;_CRT_SECURE_NO_WARNINGS;_WINDOWS;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)implementation;$(FrameworkPath);$(ContractsPath);$(WindowsPath);$(WindowsPath)zlib</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>$(OutDir);$(WindowsLibraries)\static_x64</AdditionalLibraryDirectories>
+      <AdditionalDependencies>libcrypto.lib;libssl.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+    <Lib>
+      <AdditionalLibraryDirectories>$(SolutionDir)..\artifacts\$(Configuration)\</AdditionalLibraryDirectories>
+      <IgnoreAllDefaultLibraries>true</IgnoreAllDefaultLibraries>
+    </Lib>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>DISPLAYINFO_EXPORTS;_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)implementation;$(FrameworkPath);$(ContractsPath);$(WindowsPath);$(WindowsPath)zlib</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>$(OutDir);$(WindowsLibraries)\static_x32</AdditionalLibraryDirectories>
+      <AdditionalDependencies>libcrypto.lib;libssl.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+    <Lib>
+      <AdditionalLibraryDirectories>$(SolutionDir)..\artifacts\$(Configuration)\</AdditionalLibraryDirectories>
+      <IgnoreAllDefaultLibraries>true</IgnoreAllDefaultLibraries>
+    </Lib>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>DISPLAYINFO_EXPORTS;_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)implementation;$(FrameworkPath);$(ContractsPath);$(WindowsPath);$(WindowsPath)zlib</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>$(OutDir);$(WindowsLibraries)\static_x32</AdditionalLibraryDirectories>
+      <AdditionalDependencies>libcrypto.lib;libssl.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+    <Lib>
+      <AdditionalLibraryDirectories>$(SolutionDir)..\artifacts\$(Configuration)\</AdditionalLibraryDirectories>
+      <IgnoreAllDefaultLibraries>true</IgnoreAllDefaultLibraries>
+    </Lib>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>DISPLAYINFO_EXPORTS;_CRT_SECURE_NO_WARNINGS;_WINDOWS;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)implementation;$(FrameworkPath);$(ContractsPath);$(WindowsPath);$(WindowsPath)zlib</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>$(OutDir);$(WindowsLibraries)\static_x64</AdditionalLibraryDirectories>
+      <AdditionalDependencies>libcrypto.lib;libssl.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+    <Lib>
+      <AdditionalLibraryDirectories>$(SolutionDir)..\artifacts\$(Configuration)\</AdditionalLibraryDirectories>
+      <IgnoreAllDefaultLibraries>true</IgnoreAllDefaultLibraries>
+    </Lib>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/Source/cryptography/Cryptography.vcxproj
+++ b/Source/cryptography/Cryptography.vcxproj
@@ -21,8 +21,13 @@
   <ItemGroup>
     <ClInclude Include="cryptography.h" />
     <ClInclude Include="ICryptography.h" />
+    <ClInclude Include="implementation\cipher_implementation.h" />
+    <ClInclude Include="implementation\diffiehellman_implementation.h" />
+    <ClInclude Include="implementation\hash_implementation.h" />
+    <ClInclude Include="implementation\netflix_security_implementation.h" />
     <ClInclude Include="implementation\OpenSSL\Derive.h" />
     <ClInclude Include="implementation\OpenSSL\Vault.h" />
+    <ClInclude Include="implementation\vault_implementation.h" />
     <ClInclude Include="INetflixSecurity.h" />
     <ClInclude Include="Module.h" />
   </ItemGroup>

--- a/Source/cryptography/Cryptography.vcxproj.filters
+++ b/Source/cryptography/Cryptography.vcxproj.filters
@@ -1,0 +1,63 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{79ff833a-782f-4364-a8e3-a9cac69a3afe}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{4ee8b702-cd68-4bec-8286-974510449363}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Implementation">
+      <UniqueIdentifier>{5d812b79-c997-4191-84d6-52e03a3078ff}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Implementation\Source Files">
+      <UniqueIdentifier>{bccc4e0c-4946-4fa0-a285-afa2a6f4667c}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Implementation\Header Files">
+      <UniqueIdentifier>{be2ac6f5-ca5b-4ea2-a07a-be2321f1e7d4}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="cryptography.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="ICryptography.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="INetflixSecurity.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Module.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="implementation\OpenSSL\Derive.h">
+      <Filter>Implementation\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="implementation\OpenSSL\Vault.h">
+      <Filter>Implementation\Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="Cryptography.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="NetflixSecurity.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="implementation\OpenSSL\Cipher.cpp">
+      <Filter>Implementation\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="implementation\OpenSSL\Derive.cpp">
+      <Filter>Implementation\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="implementation\OpenSSL\DiffieHellman.cpp">
+      <Filter>Implementation\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="implementation\OpenSSL\Hash.cpp">
+      <Filter>Implementation\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="implementation\OpenSSL\Vault.cpp">
+      <Filter>Implementation\Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/Source/cryptography/Cryptography.vcxproj.filters
+++ b/Source/cryptography/Cryptography.vcxproj.filters
@@ -16,6 +16,9 @@
     <Filter Include="Implementation\Header Files">
       <UniqueIdentifier>{be2ac6f5-ca5b-4ea2-a07a-be2321f1e7d4}</UniqueIdentifier>
     </Filter>
+    <Filter Include="C Interface">
+      <UniqueIdentifier>{f2f6011c-af6e-47c3-bda7-3110e4658309}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="cryptography.h">
@@ -35,6 +38,21 @@
     </ClInclude>
     <ClInclude Include="implementation\OpenSSL\Vault.h">
       <Filter>Implementation\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="implementation\cipher_implementation.h">
+      <Filter>C Interface</Filter>
+    </ClInclude>
+    <ClInclude Include="implementation\diffiehellman_implementation.h">
+      <Filter>C Interface</Filter>
+    </ClInclude>
+    <ClInclude Include="implementation\hash_implementation.h">
+      <Filter>C Interface</Filter>
+    </ClInclude>
+    <ClInclude Include="implementation\netflix_security_implementation.h">
+      <Filter>C Interface</Filter>
+    </ClInclude>
+    <ClInclude Include="implementation\vault_implementation.h">
+      <Filter>C Interface</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/Source/cryptography/ICryptography.h
+++ b/Source/cryptography/ICryptography.h
@@ -74,15 +74,19 @@ namespace Cryptography {
 
         virtual ~ICipher() { }
 
+        // Encryption and decryption, might require more bytes of data to complete succefully (like padding) to indicate the
+        // the encryption or decryption failed due to a lack of storage space, a negative length is returned. The abs(length)
+        // indicates the number of bytes required in the output buffer to succefully complete.
+
         /* Encrypt data */
-        virtual uint32_t Encrypt(const uint8_t ivLength, const uint8_t iv[] /* @length:ivLength */,
-                                 const uint32_t inputLength, const uint8_t input[] /* @length:inputLength */,
-                                 const uint32_t maxOutputLength, uint8_t output[] /* @out @maxlength:maxOutputLength */) const = 0;
+        virtual int32_t Encrypt(const uint8_t ivLength, const uint8_t iv[] /* @length:ivLength */,
+                                const uint32_t inputLength, const uint8_t input[] /* @length:inputLength */,
+                                const uint32_t maxOutputLength, uint8_t output[] /* @out @maxlength:maxOutputLength */) const = 0;
 
         /* Decrypt data */
-        virtual uint32_t Decrypt(const uint8_t ivLength, const uint8_t iv[] /* @length:ivLength */,
-                                 const uint32_t inputLength, const uint8_t input[] /* @length:inputLength */,
-                                 const uint32_t maxOutputLength, uint8_t output[] /* @out @maxlength:maxOutputLength */) const = 0;
+        virtual int32_t Decrypt(const uint8_t ivLength, const uint8_t iv[] /* @length:ivLength */,
+                                const uint32_t inputLength, const uint8_t input[] /* @length:inputLength */,
+                                const uint32_t maxOutputLength, uint8_t output[] /* @out @maxlength:maxOutputLength */) const = 0;
     };
 
     struct IDiffieHellman : virtual public Core::IUnknown {

--- a/Source/cryptography/implementation/OpenSSL/Cipher.cpp
+++ b/Source/cryptography/implementation/OpenSSL/Cipher.cpp
@@ -35,11 +35,11 @@
 
 
 struct CipherImplementation {
-    virtual uint32_t Encrypt(const uint8_t ivLength, const uint8_t iv[],
+    virtual int32_t Encrypt(const uint8_t ivLength, const uint8_t iv[],
                              const uint32_t inputLength, const uint8_t input[],
                              const uint32_t maxOutputLength, uint8_t output[]) const = 0;
 
-    virtual uint32_t Decrypt(const uint8_t ivLength, const uint8_t iv[],
+    virtual int32_t Decrypt(const uint8_t ivLength, const uint8_t iv[],
                              const uint32_t inputLength, const uint8_t input[],
                              const uint32_t maxOutputLength, uint8_t output[]) const = 0;
 
@@ -80,14 +80,14 @@ public:
         }
     }
 
-    uint32_t Encrypt(const uint8_t ivLength, const uint8_t iv[],
+    int32_t Encrypt(const uint8_t ivLength, const uint8_t iv[],
                      const uint32_t inputLength, const uint8_t input[],
                      const uint32_t maxOutputLength, uint8_t output[]) const override
     {
         return (Operation(true, ivLength, iv, inputLength, input, maxOutputLength, output));
     }
 
-    uint32_t Decrypt(const uint8_t ivLength, const uint8_t iv[],
+    int32_t Decrypt(const uint8_t ivLength, const uint8_t iv[],
                      const uint32_t inputLength, const uint8_t input[],
                      const uint32_t maxOutputLength, uint8_t output[]) const override
     {
@@ -95,12 +95,12 @@ public:
     }
 
 private:
-    uint32_t Operation(bool encrypt,
+    int32_t Operation(bool encrypt,
                        const uint8_t ivLength, const uint8_t iv[],
                        const uint32_t inputLength, const uint8_t input[],
                        const uint32_t maxOutputLength, uint8_t output[]) const
     {
-        uint32_t result = 0;
+        int32_t result = 0;
 
         ASSERT(iv != nullptr);
         ASSERT(ivLength != 0);
@@ -112,7 +112,7 @@ private:
         } else if (maxOutputLength < inputLength) {
             // Note: Pitfall, AES CBC/ECB will use padding
             TRACE_L1(_T("Too small output buffer, expected: %i bytes"), inputLength);
-            result = (~inputLength);
+            result = (-static_cast<int32_t>(inputLength  + (16 - (inputLength % 16))) );
         } else {
             uint8_t* keyBuf = reinterpret_cast<uint8_t*>(ALLOCA(_keyLength));
             ASSERT(keyBuf != nullptr);
@@ -246,14 +246,14 @@ void cipher_destroy(struct CipherImplementation* cipher)
     delete cipher;
 }
 
-uint32_t cipher_encrypt(const struct CipherImplementation* cipher, const uint8_t iv_length, const uint8_t iv[],
+int32_t cipher_encrypt(const struct CipherImplementation* cipher, const uint8_t iv_length, const uint8_t iv[],
                         const uint32_t input_length, const uint8_t input[], const uint32_t max_output_length, uint8_t output[])
 {
     ASSERT(cipher != nullptr);
     return (cipher->Encrypt(iv_length, iv, input_length, input, max_output_length, output));
 }
 
-uint32_t cipher_decrypt(const struct CipherImplementation* cipher, const uint8_t iv_length, const uint8_t iv[],
+int32_t cipher_decrypt(const struct CipherImplementation* cipher, const uint8_t iv_length, const uint8_t iv[],
                         const uint32_t input_length, const uint8_t input[], const uint32_t max_output_length, uint8_t output[])
 {
     ASSERT(cipher != nullptr);

--- a/Source/cryptography/implementation/OpenSSL/Hash.cpp
+++ b/Source/cryptography/implementation/OpenSSL/Hash.cpp
@@ -80,7 +80,7 @@ namespace Operation {
             return (EVP_DigestUpdate(ctx, d, cnt));
         }
         static int Final(EVP_MD_CTX* ctx, unsigned char* sig, size_t* siglen) {
-            uint32_t siglen32 = (*siglen);
+            uint32_t siglen32 = static_cast<uint32_t>(*siglen);
             int rv = EVP_DigestFinal(ctx, sig, &siglen32);
             (*siglen) = siglen32;
             return (rv);
@@ -194,9 +194,9 @@ public:
                     TRACE_L1(_T("Final() failed"));
                     _failure = true;
                 } else {
-                    TRACE_L2(_T("Calculated hash successfully, size: %i bytes"), len);
+                    TRACE_L2(_T("Calculated hash successfully, size: %i bytes"), static_cast<uint32_t>(len));
                     ASSERT(len == _size);
-                    result = len;
+                    result = static_cast<uint8_t>(len);
                 }
             }
         }

--- a/Source/cryptography/implementation/SecApi/Cipher.cpp
+++ b/Source/cryptography/implementation/SecApi/Cipher.cpp
@@ -66,7 +66,7 @@ namespace Implementation {
      * @return Length of the bytesWritten as encrypted blob 
      *
      *********************************************************************/
-    uint32_t Cipher::Encrypt(const uint8_t ivLength, const uint8_t iv[], const uint32_t inputLength,
+    int32_t Cipher::Encrypt(const uint8_t ivLength, const uint8_t iv[], const uint32_t inputLength,
         const uint8_t input[], const uint32_t maxOutputLength, uint8_t output[]) const
     {
         return (Operation(true, ivLength, iv, inputLength, input, maxOutputLength, output));
@@ -87,7 +87,7 @@ namespace Implementation {
      * @return Length of the bytesWritten as decrypted blob/data
      *
      *********************************************************************/
-    uint32_t Cipher::Decrypt(const uint8_t ivLength, const uint8_t iv[], const uint32_t inputLength,
+    int32_t Cipher::Decrypt(const uint8_t ivLength, const uint8_t iv[], const uint32_t inputLength,
         const uint8_t input[], const uint32_t maxOutputLength, uint8_t output[]) const
     {
         return (Operation(false, ivLength, iv, inputLength, input, maxOutputLength, output));
@@ -109,7 +109,7 @@ namespace Implementation {
      * @return Length of the bytesWritten as encrypted/decrypted blob/data
      *
      *********************************************************************/
-    uint32_t Cipher::Operation(bool encrypt, const uint8_t ivLength, const uint8_t iv[], const uint32_t inputLength,
+    int32_t Cipher::Operation(bool encrypt, const uint8_t ivLength, const uint8_t iv[], const uint32_t inputLength,
         const uint8_t input[], const uint32_t maxOutputLength, uint8_t output[]) const
     {
         SEC_SIZE OutputLength = 0;
@@ -124,7 +124,7 @@ namespace Implementation {
         else if (maxOutputLength < inputLength) {
             // Note: Pitfall, AES CBC/ECB will use padding
             TRACE_L1(_T("Too small output buffer, expected: %i bytes"), inputLength);
-            OutputLength = (-inputLength);
+            OutputLength = (-inputLength) + (16 - (inputLength % 16));
         }
         else {
             Sec_CipherHandle* cipher_handle = NULL;
@@ -274,14 +274,14 @@ extern "C" {
         delete cipher;
     }
 
-    uint32_t cipher_encrypt(const struct CipherImplementation* cipher, const uint8_t iv_length, const uint8_t iv[],
+    int32_t cipher_encrypt(const struct CipherImplementation* cipher, const uint8_t iv_length, const uint8_t iv[],
         const uint32_t input_length, const uint8_t input[], const uint32_t max_output_length, uint8_t output[])
     {
         ASSERT(cipher != nullptr);
         return (cipher->Encrypt(iv_length, iv, input_length, input, max_output_length, output));
     }
 
-    uint32_t cipher_decrypt(const struct CipherImplementation* cipher, const uint8_t iv_length, const uint8_t iv[],
+    int32_t cipher_decrypt(const struct CipherImplementation* cipher, const uint8_t iv_length, const uint8_t iv[],
         const uint32_t input_length, const uint8_t input[], const uint32_t max_output_length, uint8_t output[])
     {
         ASSERT(cipher != nullptr);

--- a/Source/cryptography/implementation/SecApi/Cipher.h
+++ b/Source/cryptography/implementation/SecApi/Cipher.h
@@ -30,10 +30,10 @@
 
 
 struct CipherImplementation {
-    virtual uint32_t Encrypt(const uint8_t ivLength, const uint8_t iv[], const uint32_t inputLength,
+    virtual int32_t Encrypt(const uint8_t ivLength, const uint8_t iv[], const uint32_t inputLength,
         const uint8_t input[], const uint32_t maxOutputLength, uint8_t output[]) const = 0;
 
-    virtual uint32_t Decrypt(const uint8_t ivLength, const uint8_t iv[], const uint32_t inputLength,
+    virtual int32_t Decrypt(const uint8_t ivLength, const uint8_t iv[], const uint32_t inputLength,
         const uint8_t input[], const uint32_t maxOutputLength, uint8_t output[]) const = 0;
 
     virtual ~CipherImplementation() { }
@@ -58,10 +58,10 @@ namespace Implementation {
             const uint8_t input[], const uint32_t maxOutputLength, uint8_t output[]) const;
 
         const Sec_CipherAlgorithm AESCipher(const aes_mode mode);
-        uint32_t Encrypt(const uint8_t ivLength, const uint8_t iv[], const uint32_t inputLength,
+        int32_t Encrypt(const uint8_t ivLength, const uint8_t iv[], const uint32_t inputLength,
             const uint8_t input[], const uint32_t maxOutputLength, uint8_t output[]) const override;
 
-        uint32_t Decrypt(const uint8_t ivLength, const uint8_t iv[], const uint32_t inputLength,
+        int32_t Decrypt(const uint8_t ivLength, const uint8_t iv[], const uint32_t inputLength,
             const uint8_t input[], const uint32_t maxOutputLength, uint8_t output[]) const override;
 
     private:
@@ -90,13 +90,13 @@ namespace Implementation {
     public:
 
         const Sec_CipherAlgorithm AESCipher(const aes_mode mode);
-        uint32_t Encrypt(const uint8_t ivLength, const uint8_t iv[], const uint32_t inputLength,
+        int32_t Encrypt(const uint8_t ivLength, const uint8_t iv[], const uint32_t inputLength,
             const uint8_t input[], const uint32_t maxOutputLength, uint8_t output[]) const override;
 
-        uint32_t Decrypt(const uint8_t ivLength, const uint8_t iv[], const uint32_t inputLength,
+        int32_t Decrypt(const uint8_t ivLength, const uint8_t iv[], const uint32_t inputLength,
             const uint8_t input[], const uint32_t maxOutputLength, uint8_t output[]) const override;
 
-        uint32_t Operation(bool encrypt, const uint8_t ivLength, const uint8_t iv[], const uint32_t inputLength,
+        int32_t Operation(bool encrypt, const uint8_t ivLength, const uint8_t iv[], const uint32_t inputLength,
             const uint8_t input[], const uint32_t maxOutputLength, uint8_t output[]) const;
     };
 

--- a/Source/cryptography/implementation/Thunder/Cipher.cpp
+++ b/Source/cryptography/implementation/Thunder/Cipher.cpp
@@ -29,11 +29,13 @@
 
 
 struct CryptImplementation {
-    virtual uint32_t Operation(const uint8_t ivLength, const uint8_t iv[],
+
+    virtual ~CryptImplementation() = default;
+
+    virtual int32_t Operation(const uint8_t ivLength, const uint8_t iv[],
                                const uint32_t inputLength, const uint8_t input[],
                                const uint32_t maxOutputLength, uint8_t output[]) = 0;
 
-    virtual ~CryptImplementation() { }
 };
 
 
@@ -45,14 +47,14 @@ namespace Operation {
 
     struct Encrypt {
         typedef WPEFramework::Crypto::AESEncryption Implementation;
-        static uint32_t Operation(Implementation& impl, const uint32_t length, const uint8_t input[], uint8_t output[]) {
+        static int32_t Operation(Implementation& impl, const uint32_t length, const uint8_t input[], uint8_t output[]) {
             return (impl.Encrypt(length, input, output));
         }
     };
 
     struct Decrypt {
         typedef WPEFramework::Crypto::AESDecryption Implementation;
-        static uint32_t Operation(Implementation& impl, const uint32_t length, const uint8_t input[], uint8_t output[]) {
+        static int32_t Operation(Implementation& impl, const uint32_t length, const uint8_t input[], uint8_t output[]) {
             return (impl.Decrypt(length, input, output));
         }
     };
@@ -95,7 +97,7 @@ public:
             TRACE_L1(_T("Invalid IV length: %i"), ivLength);
         } else if (maxOutputLength < inputLength) {
             TRACE_L1(_T("Output buffer too small, need  %i bytes"), inputLength);
-            result = (-inputLength);
+            result = (-inputLength) + (16 - (inputLength % 16));
         } else {
             _cryptor.InitialVector(iv);
 

--- a/Source/cryptography/implementation/cipher_implementation.h
+++ b/Source/cryptography/implementation/cipher_implementation.h
@@ -44,10 +44,10 @@ struct CipherImplementation* cipher_create_aes(const struct VaultImplementation*
 void cipher_destroy(struct CipherImplementation* cipher);
 
 
-uint32_t cipher_encrypt(const struct CipherImplementation* cipher, const uint8_t iv_length, const uint8_t iv[],
+int32_t cipher_encrypt(const struct CipherImplementation* cipher, const uint8_t iv_length, const uint8_t iv[],
                         const uint32_t input_length, const uint8_t input[], const uint32_t max_output_length, uint8_t output[]);
 
-uint32_t cipher_decrypt(const struct CipherImplementation* cipher, const uint8_t iv_length, const uint8_t iv[],
+int32_t cipher_decrypt(const struct CipherImplementation* cipher, const uint8_t iv_length, const uint8_t iv[],
                         const uint32_t input_length, const uint8_t input[], const uint32_t max_output_length, uint8_t output[]);
 
 #ifdef __cplusplus


### PR DESCRIPTION
This prepares the OpenSSL implementation to work with the latest interface (OpenSSL1.1) it is also preparred to be compiled and used in a windows environment.
