### PR TITLE
Weston: waylandsink: Add GetNativeSurface() api

### DIFF
--- a/Source/compositorclient/Client.h
+++ b/Source/compositorclient/Client.h
@@ -190,6 +190,7 @@ namespace Compositor {
         virtual ISurface* Create(const std::string& name, const uint32_t width, const uint32_t height) = 0; //initial position on screen is fullscreen,x and y therefore implicit and 0
         virtual int Process(const uint32_t data) = 0;
         virtual int FileDescriptor() const = 0;
+	virtual void* GetNativeSurface(const std::string& name) = 0;
     };
 } // Compositor
 } // WPEFramework

--- a/Source/compositorclient/Wayland/Implementation.h
+++ b/Source/compositorclient/Wayland/Implementation.h
@@ -593,7 +593,7 @@ namespace Wayland {
         virtual int FileDescriptor() const override;
         virtual int Process(const uint32_t data) override;
         virtual ISurface* Create(const std::string& name, const uint32_t width, const uint32_t height) override;
-
+	virtual void* GetNativeSurface(const std::string& name);
         inline bool IsOperational() const
         {
             return (_display != nullptr);

--- a/Source/compositorclient/Wayland/Weston.cpp
+++ b/Source/compositorclient/Wayland/Weston.cpp
@@ -972,7 +972,6 @@ namespace Wayland {
             surface->_wait_for_configure = true;
             wl_surface_commit(surface->_surface);
 
-            xdg_toplevel_set_fullscreen(surface->_xdg_toplevel, NULL);
         }
 
         // Wait till we are fully registered.

--- a/Source/compositorclient/Wayland/Weston.cpp
+++ b/Source/compositorclient/Wayland/Weston.cpp
@@ -430,7 +430,7 @@ namespace Wayland {
 
             wl_region_destroy(region);
 
-            Trace("Creating a surface of size: %d x %d\n", width, height);
+            Trace("Creating a surface of size: %d x %d _surface=%p\n", width, height, _surface);
 
             _native = wl_egl_window_create(_surface, width, height);
 
@@ -947,6 +947,28 @@ namespace Wayland {
         _collect |= true;
     }
 
+    void* Display::GetNativeSurface(const std::string& name)
+    {
+        Trace("Display::GetNativeSurface() name=%s\n", name.c_str());
+	//iterate through waylandsurface map return wl_surface with matching name
+
+	_adminLock.Lock();
+
+        WaylandSurfaceMap::iterator entry(_waylandSurfaces.begin());
+
+        while (entry != _waylandSurfaces.end()) {
+	  if (entry->second->Name().compare(name) == 0); {
+	    Trace("Display::GetNativeSurface - surface names match (name=%s)!\n", name.c_str());
+	    _adminLock.Unlock();
+	    //return wl_surface to upper layers
+	    return entry->first;
+	  }
+          entry++;
+        }
+	Trace("Display::GetNativeSurface() surface not found!-");
+	_adminLock.Unlock();
+	return nullptr;
+    }
 
     Compositor::IDisplay::ISurface* Display::Create(const std::string& name, const uint32_t width, const uint32_t height)
     {


### PR DESCRIPTION
This pull request adds a new API GetNativeSurface() to the Weston wayland compositor client code. This is used by wpebackend-rdk to obtain the webkit browser surface created by Thunder (see pull request here https://github.com/WebPlatformForEmbedded/WPEBackend-rdk/pull/55).

The reason for adding this api, is so that we can use GStreamer waylandsink as the video sink in wpewebkit (instead of westeros sink). For this to function correctly GStreamer backend in wpewebkit needs to set an external surface (the one created by Thunder), so that the video surface is correctly created as a sub-surface of the browser.

The following video demonstrates this which shows Widevine EME playback using OP-TEE, using Weston compositor, Thunder/wpeframework and OpenCDM, plus webkit using waylandsink as the video sink. https://photos.app.goo.gl/DEKhcYmWfxRsFDxw7

The removal of xdg_toplevel_set_fullscreen() fixes a bug whereby Thunder wouldn't start if the display output didn't match what webkit plugin was configured to.