### PR TITLE
compositorclient: add SurfaceByName() and NativeSurface() apis

### DIFF
--- a/Source/compositorclient/Client.h
+++ b/Source/compositorclient/Client.h
@@ -190,6 +190,7 @@ namespace Compositor {
         virtual ISurface* Create(const std::string& name, const uint32_t width, const uint32_t height) = 0; //initial position on screen is fullscreen,x and y therefore implicit and 0
         virtual int Process(const uint32_t data) = 0;
         virtual int FileDescriptor() const = 0;
+	virtual ISurface* SurfaceByName(const std::string& name) = 0;
     };
 } // Compositor
 } // WPEFramework

--- a/Source/compositorclient/RPI/Implementation.cpp
+++ b/Source/compositorclient/RPI/Implementation.cpp
@@ -898,6 +898,12 @@ int Display::FileDescriptor() const
     return (g_pipefd[0]);
 }
 
+Compositor::IDisplay::ISurface* Display::SurfaceByName(const std::string& name)
+{
+    //TODO not implemented
+    return nullptr;
+}
+
 Compositor::IDisplay::ISurface* Display::Create(
     const std::string& name, const uint32_t width, const uint32_t height)
 {

--- a/Source/compositorclient/Wayland/Implementation.h
+++ b/Source/compositorclient/Wayland/Implementation.h
@@ -593,7 +593,24 @@ namespace Wayland {
         virtual int FileDescriptor() const override;
         virtual int Process(const uint32_t data) override;
         virtual ISurface* Create(const std::string& name, const uint32_t width, const uint32_t height) override;
-	virtual void* GetNativeSurface(const std::string& name);
+	virtual ISurface* SurfaceByName(const std::string& name) override
+	{
+	    //iterate through waylandsurface map return wl_surface with matching name
+	    _adminLock.Lock();
+
+	    WaylandSurfaceMap::iterator entry(_waylandSurfaces.begin());
+
+	    while (entry != _waylandSurfaces.end()) {
+	      if (entry->second->Name().compare(name) == 0) {
+	        _adminLock.Unlock();
+	        //return iSurface to upper layers
+	        return entry->second;
+	      }
+	      entry++;
+	    }
+	    _adminLock.Unlock();
+	    return nullptr;
+	}
         inline bool IsOperational() const
         {
             return (_display != nullptr);

--- a/Source/compositorclient/Wayland/Weston.cpp
+++ b/Source/compositorclient/Wayland/Weston.cpp
@@ -947,29 +947,6 @@ namespace Wayland {
         _collect |= true;
     }
 
-    void* Display::GetNativeSurface(const std::string& name)
-    {
-        Trace("Display::GetNativeSurface() name=%s\n", name.c_str());
-	//iterate through waylandsurface map return wl_surface with matching name
-
-	_adminLock.Lock();
-
-        WaylandSurfaceMap::iterator entry(_waylandSurfaces.begin());
-
-        while (entry != _waylandSurfaces.end()) {
-	  if (entry->second->Name().compare(name) == 0); {
-	    Trace("Display::GetNativeSurface - surface names match (name=%s)!\n", name.c_str());
-	    _adminLock.Unlock();
-	    //return wl_surface to upper layers
-	    return entry->first;
-	  }
-          entry++;
-        }
-	Trace("Display::GetNativeSurface() surface not found!-");
-	_adminLock.Unlock();
-	return nullptr;
-    }
-
     Compositor::IDisplay::ISurface* Display::Create(const std::string& name, const uint32_t width, const uint32_t height)
     {
         IDisplay::ISurface* result = nullptr;


### PR DESCRIPTION
Re-worked previous implementation a bit following Pierres review
feedback to better map to the existing IDisplay & ISurface classes.

SurfaceByName() is used on the IDisplay class to get the ISurface.
NativeSurface() is used on the ISurface to get the native surface.

These api's are used with Wayland Weston compositor client when
using waylandsink as the video sink in webkit. I've moved the implementation
to the Implementation.h header which is shared between Westeros and Weston.

wpebackend-rdk calls these apis to obtain the surface handle created by
Thunder, which is then passed to waylandsink as an external surface so
that the video surface is correctly created as a sub-surface
of the browser.

Also RPI compositorclient is updated to have a stub implementation.

Signed-off-by: Peter Griffin <peter.griffin@linaro.org>