### PR TITLE
Send empty buffer on no boundkey file present case

### DIFF
--- a/Source/cryptography/implementation/SecApi/VaultNetflix.cpp
+++ b/Source/cryptography/implementation/SecApi/VaultNetflix.cpp
@@ -19,7 +19,7 @@
 
 #include "../../Module.h"
 #include "Vault.h"
-
+#define MAX_FILE_SIZE 300
 namespace Implementation {
 
     
@@ -38,14 +38,17 @@ namespace Implementation {
             std::string path;
             WPEFramework::Core::SystemInfo::GetEnvironment(_T("NETFLIX_VAULT"), path);
             WPEFramework::Core::File file(path.c_str(), true);
+            /*Send an empty buffer for cases where boundndkymsg File is not required or  present.
+            The buffer content will be ignored by Secapi-Netflix lib for such cases*/    
+            uint8_t buf[MAX_FILE_SIZE]={0};
+            uint16_t inSize = MAX_FILE_SIZE;
             if (file.Open(true) == true) {
                 uint64_t fileSize = file.Size();
-                uint8_t buf[fileSize];
-                uint16_t inSize = file.Read(buf, fileSize);
+                inSize = file.Read(buf, fileSize);
                 file.Close();
-                bool result = netflix.loadBoundKeys(buf, inSize);
-                ASSERT(result == true);
             }
+            bool result = netflix.loadBoundKeys(buf, inSize);
+            ASSERT(result == true);
         };
 
         auto dtor = [](VaultNetflix& netflix) {

--- a/Source/cryptography/implementation/SecApi/VaultNetflix.cpp
+++ b/Source/cryptography/implementation/SecApi/VaultNetflix.cpp
@@ -19,7 +19,6 @@
 
 #include "../../Module.h"
 #include "Vault.h"
-#define MAX_FILE_SIZE 300
 namespace Implementation {
 
     
@@ -40,8 +39,9 @@ namespace Implementation {
             WPEFramework::Core::File file(path.c_str(), true);
             /*Send an empty buffer for cases where boundndkymsg File is not required or  present.
             The buffer content will be ignored by Secapi-Netflix lib for such cases*/    
-            uint8_t buf[MAX_FILE_SIZE]={0};
-            uint16_t inSize = MAX_FILE_SIZE;
+            static constexpr uint32_t MaxFileSize = 300;
+            uint8_t buf[MaxFileSize]={0};
+            uint16_t inSize = MaxFileSize;
             if (file.Open(true) == true) {
                 uint64_t fileSize = file.Size();
                 inSize = file.Read(buf, fileSize);


### PR DESCRIPTION
For cases where SOC specific Netflix MGK Backend is use, boundkey msg file is not required. If file is prsent that content will be passed. If file is not present empty buffer is passed, which will be ignored by SOC  Secapi-Netflix library.