### PR TITLE
[METRO-143] ocdm client instance creation

### DIFF
--- a/Source/ocdm/Module.h
+++ b/Source/ocdm/Module.h
@@ -24,6 +24,7 @@
 #endif
 
 #include <core/core.h>
+#include <core/Singleton.h>
 #include <com/com.h>
 
 #if defined(__WINDOWS__) && defined(OCDM_EXPORTS)

--- a/Source/ocdm/open_cdm.cpp
+++ b/Source/ocdm/open_cdm.cpp
@@ -98,7 +98,6 @@ KeyStatus CDMState(const OCDM::ISession::KeyStatus state)
     return KeyStatus::InternalError;
 }
 
-/* static */ OpenCDMAccessor* OpenCDMAccessor::_singleton = nullptr;
 
 /**
  * Destructs an \ref OpenCDMAccessor instance.


### PR DESCRIPTION
 - Reason for change :  Improvement, memory leak fix
     The method:
        static OpenCDMAccessor* Instance()
     is currently casuing a memory leak of this instance.

 - Solution :
         Suggest to instantiate a OCDMAccessor through lazy creation in order to
         get "properly" destructed on app closure.
         As an improvement, use variadic template in Singleton implementation.