### PR TITLE
[DisplayInfo] Added automatic reconnection, changed interfaces. 

### DIFF
--- a/Source/displayinfo/DisplayInfo.cpp
+++ b/Source/displayinfo/DisplayInfo.cpp
@@ -126,7 +126,7 @@ private:
                 _hdrProperties = nullptr;
             }
             if (_displayConnection != nullptr) {
-                _displayConnection->Register(&_displayUpdatedNotification);
+                _displayConnection->Unregister(&_displayUpdatedNotification);
                 _displayConnection->Release();
                 _displayConnection = nullptr;
             }
@@ -380,9 +380,11 @@ struct displayinfo_type* displayinfo_instance()
     return reinterpret_cast<displayinfo_type*>(DisplayInfo::Instance());
 }
 
-void displayinfo_release(struct displayinfo_type* displayinfo)
+void displayinfo_release(struct displayinfo_type* instance)
 {
-    reinterpret_cast<DisplayInfo*>(displayinfo)->DestroyInstance();
+    if (instance != NULL) {
+        reinterpret_cast<DisplayInfo*>(instance)->DestroyInstance();
+    }
 }
 
 uint32_t displayinfo_register_operational_state_change_callback(struct displayinfo_type* instance,
@@ -532,6 +534,7 @@ uint32_t displayinfo_hdcp_protection(struct displayinfo_type* instance, displayi
     if (instance != NULL && hdcp != NULL) {
         Exchange::IConnectionProperties::HDCPProtectionType value = Exchange::IConnectionProperties::HDCPProtectionType::HDCP_AUTO;
         *hdcp = DISPLAYINFO_HDCP_UNKNOWN;
+
         if (reinterpret_cast<DisplayInfo*>(instance)->HDCPProtection(value) == Core::ERROR_NONE) {
             switch (value) {
             case Exchange::IConnectionProperties::HDCP_Unencrypted:
@@ -550,8 +553,8 @@ uint32_t displayinfo_hdcp_protection(struct displayinfo_type* instance, displayi
                 return Core::ERROR_UNKNOWN_KEY;
                 break;
             }
+            return Core::ERROR_NONE;
         }
-        return Core::ERROR_NONE;
     }
     return Core::ERROR_UNAVAILABLE;
 }

--- a/Source/displayinfo/DisplayInfo.cpp
+++ b/Source/displayinfo/DisplayInfo.cpp
@@ -279,139 +279,216 @@ public:
     }
 };
 
+std::unique_ptr<DisplayInfo> DisplayInfo::_instance = nullptr;
+
 } // namespace WPEFramework
 
 using namespace WPEFramework;
 
 extern "C" {
-struct displayinfo_type* displayinfo_instance(const char displayName[] = "DisplayInfo")
+struct displayinfo_type* displayinfo_instance()
 {
-    //return reinterpret_cast<displayinfo_type*>(DisplayInfo::Instance());
+    return reinterpret_cast<displayinfo_type*>(DisplayInfo::Instance());
 }
 
 void displayinfo_release(struct displayinfo_type* displayinfo)
 {
-    //reinterpret_cast<DisplayInfo*>(displayinfo)->DestroyInstance();
+    reinterpret_cast<DisplayInfo*>(displayinfo)->DestroyInstance();
 }
 
-void displayinfo_register(struct displayinfo_type* displayinfo, displayinfo_updated_cb callback, void* userdata)
+void displayinfo_register(struct displayinfo_type* instance, displayinfo_updated_cb callback, void* userdata)
 {
     // TODO reinterpret_cast<DisplayInfo*>(displayinfo)->Register(callback, userdata);
 }
 
-void displayinfo_unregister(struct displayinfo_type* displayinfo, displayinfo_updated_cb callback)
+void displayinfo_unregister(struct displayinfo_type* instance, displayinfo_updated_cb callback)
 {
     // TODO reinterpret_cast<DisplayInfo*>(displayinfo)->Unregister(callback);
 }
 
-void displayinfo_name(struct displayinfo_type* displayinfo, char buffer[], const uint8_t length)
+void displayinfo_name(struct displayinfo_type* instance, char buffer[], const uint8_t length)
 {
-    //string name = reinterpret_cast<DisplayInfo*>(displayinfo)->Name();
-    //strncpy(buffer, name.c_str(), length);
+    string name = reinterpret_cast<DisplayInfo*>(instance)->Name();
+    strncpy(buffer, name.c_str(), length);
 }
 
-bool displayinfo_is_audio_passthrough(struct displayinfo_type* displayinfo)
+uint32_t displayinfo_is_audio_passthrough(struct displayinfo_type* instance, bool* is_passthrough)
 {
-    //return reinterpret_cast<DisplayInfo*>(displayinfo)->IsAudioPassthrough();
-}
+    uint32_t errorCode = Core::ERROR_UNAVAILABLE;
 
-bool displayinfo_connected(struct displayinfo_type* displayinfo)
-{
-    //return reinterpret_cast<DisplayInfo*>(displayinfo)->Connected();
-}
-
-uint32_t displayinfo_width(struct displayinfo_type* displayinfo)
-{
-    //return reinterpret_cast<DisplayInfo*>(displayinfo)->Width();
-}
-
-uint32_t displayinfo_height(struct displayinfo_type* displayinfo)
-{
-    //return reinterpret_cast<DisplayInfo*>(displayinfo)->Height();
-}
-
-uint32_t displayinfo_vertical_frequency(struct displayinfo_type* displayinfo)
-{
-    //return reinterpret_cast<DisplayInfo*>(displayinfo)->VerticalFreq();
-}
-
-displayinfo_hdr_t displayinfo_hdr(struct displayinfo_type* displayinfo)
-{
-    /*
-    displayinfo_hdr_t result = DISPLAYINFO_HDR_UNKNOWN;
-
-    switch (reinterpret_cast<DisplayInfo*>(displayinfo)->HDR()) {
-    case Exchange::IHDRProperties::HDR_OFF:
-        result = DISPLAYINFO_HDR_OFF;
-        break;
-    case Exchange::IHDRProperties::HDR_10:
-        result = DISPLAYINFO_HDR_10;
-        break;
-    case Exchange::IHDRProperties::HDR_10PLUS:
-        result = DISPLAYINFO_HDR_10PLUS;
-        break;
-    case Exchange::IHDRProperties::HDR_DOLBYVISION:
-        result = DISPLAYINFO_HDR_DOLBYVISION;
-        break;
-    case Exchange::IHDRProperties::HDR_TECHNICOLOR:
-        result = DISPLAYINFO_HDR_TECHNICOLOR;
-        break;
-    default:
-        result = DISPLAYINFO_HDR_UNKNOWN;
-        break;
+    if (instance != NULL && is_passthrough != NULL) {
+        errorCode = reinterpret_cast<DisplayInfo*>(instance)->IsAudioPassthrough(*is_passthrough);
     }
 
-    return result;
-    */
+    return errorCode;
 }
 
-displayinfo_hdcp_protection_t displayinfo_hdcp_protection(struct displayinfo_type* displayinfo)
+uint32_t displayinfo_connected(struct displayinfo_type* instance, bool* is_connected)
 {
-    /*
-    displayinfo_hdcp_protection_t type = DISPLAYINFO_HDCP_UNKNOWN;
+    uint32_t errorCode = Core::ERROR_UNAVAILABLE;
 
-    switch (reinterpret_cast<DisplayInfo*>(displayinfo)->HDCPProtection()) {
-    case Exchange::IConnectionProperties::HDCP_Unencrypted:
-        type = DISPLAYINFO_HDCP_UNENCRYPTED;
-        break;
-    case Exchange::IConnectionProperties::HDCP_1X:
-        type = DISPLAYINFO_HDCP_1X;
-        break;
-    case Exchange::IConnectionProperties::HDCP_2X:
-        type = DISPLAYINFO_HDCP_2X;
-        break;
-    default:
-        type = DISPLAYINFO_HDCP_UNKNOWN;
-        break;
+    if (instance != NULL && is_connected != NULL) {
+        errorCode = reinterpret_cast<DisplayInfo*>(instance)->Connected(*is_connected);
     }
 
-    return type;
-    */
+    return errorCode;
 }
 
-uint64_t displayinfo_total_gpu_ram(struct displayinfo_type* instance)
+uint32_t displayinfo_width(struct displayinfo_type* instance, uint32_t* width)
 {
-    //  return reinterpret_cast<DisplayInfo*>(instance)->TotalGpuRam();
+    uint32_t errorCode = Core::ERROR_UNAVAILABLE;
+
+    if (instance != NULL && width != NULL) {
+        errorCode = reinterpret_cast<DisplayInfo*>(instance)->Width(*width);
+    }
+
+    return errorCode;
 }
 
-uint64_t displayinfo_free_gpu_ram(struct displayinfo_type* instance)
+uint32_t displayinfo_height(struct displayinfo_type* instance, uint32_t* height)
 {
-    //return reinterpret_cast<DisplayInfo*>(instance)->FreeGpuRam();
+    uint32_t errorCode = Core::ERROR_UNAVAILABLE;
+
+    if (instance != NULL && height != NULL) {
+        errorCode = reinterpret_cast<DisplayInfo*>(instance)->Height(*height);
+    }
+
+    return errorCode;
 }
 
-uint32_t displayinfo_edid(struct displayinfo_type* displayinfo, uint8_t buffer[], uint16_t* length)
+uint32_t displayinfo_vertical_frequency(struct displayinfo_type* instance, uint32_t* vertical_freq)
 {
-    //return reinterpret_cast<DisplayInfo*>(displayinfo)->EDID(*length, buffer);
+
+    uint32_t errorCode = Core::ERROR_UNAVAILABLE;
+
+    if (instance != NULL && vertical_freq != NULL) {
+        errorCode = reinterpret_cast<DisplayInfo*>(instance)->VerticalFreq(*vertical_freq);
+    }
+
+    return errorCode;
 }
 
-uint8_t displayinfo_width_in_centimeters(struct displayinfo_type* displayinfo)
+EXTERNAL uint32_t displayinfo_hdr(struct displayinfo_type* instance, displayinfo_hdr_t* hdr)
 {
-    //return reinterpret_cast<DisplayInfo*>(displayinfo)->WidthInCentimeters();
+
+    if (instance != NULL && hdr != NULL) {
+        Exchange::IHDRProperties::HDRType value = Exchange::IHDRProperties::HDRType::HDR_OFF;
+        *hdr = DISPLAYINFO_HDR_UNKNOWN;
+
+        if (reinterpret_cast<DisplayInfo*>(instance)->HDR(value) == Core::ERROR_NONE) {
+            switch (value) {
+            case Exchange::IHDRProperties::HDR_OFF:
+                *hdr = DISPLAYINFO_HDR_OFF;
+                break;
+            case Exchange::IHDRProperties::HDR_10:
+                *hdr = DISPLAYINFO_HDR_10;
+                break;
+            case Exchange::IHDRProperties::HDR_10PLUS:
+                *hdr = DISPLAYINFO_HDR_10PLUS;
+                break;
+            case Exchange::IHDRProperties::HDR_DOLBYVISION:
+                *hdr = DISPLAYINFO_HDR_DOLBYVISION;
+                break;
+            case Exchange::IHDRProperties::HDR_TECHNICOLOR:
+                *hdr = DISPLAYINFO_HDR_TECHNICOLOR;
+                break;
+            default:
+                fprintf(stderr, "New HDR type in the interface, not handled in client library\n");
+                ASSERT(false && "Invalid enum");
+                *hdr = DISPLAYINFO_HDR_UNKNOWN;
+                return Core::ERROR_UNKNOWN_KEY;
+                break;
+            }
+            return Core::ERROR_NONE;
+        }
+    }
+
+    return Core::ERROR_UNAVAILABLE;
 }
 
-uint8_t displayinfo_height_in_centimeters(struct displayinfo_type* displayinfo)
+uint32_t displayinfo_hdcp_protection(struct displayinfo_type* instance, displayinfo_hdcp_protection_t* hdcp)
 {
-    //return reinterpret_cast<DisplayInfo*>(displayinfo)->HeightInCentimeters();
+    if (instance != NULL && hdcp != NULL) {
+        Exchange::IConnectionProperties::HDCPProtectionType value = Exchange::IConnectionProperties::HDCPProtectionType::HDCP_AUTO;
+        *hdcp = DISPLAYINFO_HDCP_UNKNOWN;
+        if (reinterpret_cast<DisplayInfo*>(instance)->HDCPProtection(value) == Core::ERROR_NONE) {
+            switch (value) {
+            case Exchange::IConnectionProperties::HDCP_Unencrypted:
+                *hdcp = DISPLAYINFO_HDCP_UNENCRYPTED;
+                break;
+            case Exchange::IConnectionProperties::HDCP_1X:
+                *hdcp = DISPLAYINFO_HDCP_1X;
+                break;
+            case Exchange::IConnectionProperties::HDCP_2X:
+                *hdcp = DISPLAYINFO_HDCP_2X;
+                break;
+            default:
+                fprintf(stderr, "New HDCP type in the interface, not handled in client library\n");
+                ASSERT(false && "Invalid enum");
+                *hdcp = DISPLAYINFO_HDCP_UNKNOWN;
+                return Core::ERROR_UNKNOWN_KEY;
+                break;
+            }
+        }
+        return Core::ERROR_NONE;
+    }
+    return Core::ERROR_UNAVAILABLE;
+}
+
+uint32_t displayinfo_total_gpu_ram(struct displayinfo_type* instance, uint64_t* total_ram)
+{
+
+    uint32_t errorCode = Core::ERROR_UNAVAILABLE;
+
+    if (instance != NULL && total_ram != NULL) {
+        errorCode = reinterpret_cast<DisplayInfo*>(instance)->TotalGpuRam(*total_ram);
+    }
+
+    return errorCode;
+}
+
+uint32_t displayinfo_free_gpu_ram(struct displayinfo_type* instance, uint64_t* free_ram)
+{
+    uint32_t errorCode = Core::ERROR_UNAVAILABLE;
+
+    if (instance != NULL && free_ram != NULL) {
+        errorCode = reinterpret_cast<DisplayInfo*>(instance)->FreeGpuRam(*free_ram);
+    }
+
+    return errorCode;
+}
+
+uint32_t displayinfo_edid(struct displayinfo_type* instance, uint8_t buffer[], uint16_t* length)
+{
+    uint32_t errorCode = Core::ERROR_UNAVAILABLE;
+
+    if (instance != NULL && buffer != NULL && length != NULL) {
+        errorCode = reinterpret_cast<DisplayInfo*>(instance)->EDID(*length, buffer);
+    }
+
+    return errorCode;
+}
+
+uint32_t displayinfo_width_in_centimeters(struct displayinfo_type* instance, uint8_t* width)
+{
+    uint32_t errorCode = Core::ERROR_UNAVAILABLE;
+
+    if (instance != NULL && width != NULL) {
+        errorCode = reinterpret_cast<DisplayInfo*>(instance)->WidthInCentimeters(*width);
+    }
+
+    return errorCode;
+}
+
+uint32_t displayinfo_height_in_centimeters(struct displayinfo_type* instance, uint8_t* height)
+{
+    uint32_t errorCode = Core::ERROR_UNAVAILABLE;
+
+    if (instance != NULL && height != NULL) {
+        errorCode = reinterpret_cast<DisplayInfo*>(instance)->HeightInCentimeters(*height);
+    }
+
+    return errorCode;
 }
 
 bool displayinfo_is_atmos_supported(struct displayinfo_type* displayinfo)

--- a/Source/displayinfo/DisplayInfo.cpp
+++ b/Source/displayinfo/DisplayInfo.cpp
@@ -176,27 +176,32 @@ public:
         return _callsign;
     }
 
-    void RegisterOperationalStateChangedCallback(displayinfo_operational_state_change_cb callback, void* userdata)
+    uint32_t RegisterOperationalStateChangedCallback(displayinfo_operational_state_change_cb callback, void* userdata)
     {
+
         OperationalStateChangeCallbacks::iterator index(_operationalStateCallbacks.find(callback));
 
         if (index == _operationalStateCallbacks.end()) {
             _operationalStateCallbacks.emplace(std::piecewise_construct,
                 std::forward_as_tuple(callback),
                 std::forward_as_tuple(userdata));
+            return Core::ERROR_NONE;
         }
+        return Core::ERROR_GENERAL;
     }
 
-    void UnregisterOperationalStateChangedCallback(displayinfo_operational_state_change_cb callback)
+    uint32_t UnregisterOperationalStateChangedCallback(displayinfo_operational_state_change_cb callback)
     {
         OperationalStateChangeCallbacks::iterator index(_operationalStateCallbacks.find(callback));
 
         if (index != _operationalStateCallbacks.end()) {
             _operationalStateCallbacks.erase(index);
+            return Core::ERROR_NONE;
         }
+        return Core::ERROR_NOT_EXIST;
     }
 
-    void RegisterDisplayOutputChangeCallback(displayinfo_display_output_change_cb callback, void* userdata)
+    uint32_t RegisterDisplayOutputChangeCallback(displayinfo_display_output_change_cb callback, void* userdata)
     {
         DisplayOutputUpdatedCallbacks::iterator index(_displayChangeCallbacks.find(callback));
 
@@ -204,16 +209,20 @@ public:
             _displayChangeCallbacks.emplace(std::piecewise_construct,
                 std::forward_as_tuple(callback),
                 std::forward_as_tuple(userdata));
+            return Core::ERROR_NONE;
         }
+        return Core::ERROR_GENERAL;
     }
 
-    void UnregisterDolbyAudioModeChangedCallback(displayinfo_display_output_change_cb callback)
+    uint32_t UnregisterDolbyAudioModeChangedCallback(displayinfo_display_output_change_cb callback)
     {
         DisplayOutputUpdatedCallbacks::iterator index(_displayChangeCallbacks.find(callback));
 
         if (index != _displayChangeCallbacks.end()) {
             _displayChangeCallbacks.erase(index);
+            return Core::ERROR_NONE;
         }
+        return Core::ERROR_NOT_EXIST;
     }
 
     uint32_t IsAudioPassthrough(bool& outIsEnabled) const
@@ -376,29 +385,46 @@ void displayinfo_release(struct displayinfo_type* displayinfo)
     reinterpret_cast<DisplayInfo*>(displayinfo)->DestroyInstance();
 }
 
-void displayinfo_register_operational_state_change_callback(struct displayinfo_type* instance,
+uint32_t displayinfo_register_operational_state_change_callback(struct displayinfo_type* instance,
     displayinfo_operational_state_change_cb callback,
     void* userdata)
 {
+    uint32_t errorCode = Core::ERROR_UNAVAILABLE;
+    if (instance != NULL) {
+        errorCode = reinterpret_cast<DisplayInfo*>(instance)->RegisterOperationalStateChangedCallback(callback, userdata);
+    }
+    return errorCode;
 }
 
-void displayinfo_unregister_operational_state_change_callback(struct displayinfo_type* instance,
+uint32_t displayinfo_unregister_operational_state_change_callback(struct displayinfo_type* instance,
     displayinfo_operational_state_change_cb callback)
 {
+    uint32_t errorCode = Core::ERROR_UNAVAILABLE;
+    if (instance != NULL) {
+        errorCode = reinterpret_cast<DisplayInfo*>(instance)->UnregisterOperationalStateChangedCallback(callback);
+    }
+    return errorCode;
 }
 
-void displayinfo_register_display_output_change_callback(struct displayinfo_type* instance, displayinfo_display_output_change_cb callback, void* userdata)
+uint32_t displayinfo_register_display_output_change_callback(struct displayinfo_type* instance, displayinfo_display_output_change_cb callback, void* userdata)
 {
+    uint32_t errorCode = Core::ERROR_UNAVAILABLE;
+
     if (instance != NULL) {
-        reinterpret_cast<DisplayInfo*>(instance)->RegisterDisplayOutputChangeCallback(callback, userdata);
+        errorCode = reinterpret_cast<DisplayInfo*>(instance)->RegisterDisplayOutputChangeCallback(callback, userdata);
     }
+    return errorCode;
 }
 
-void displayinfo_unregister_display_output_change_callback(struct displayinfo_type* instance, displayinfo_display_output_change_cb callback)
+uint32_t displayinfo_unregister_display_output_change_callback(struct displayinfo_type* instance, displayinfo_display_output_change_cb callback)
 {
+    uint32_t errorCode = Core::ERROR_UNAVAILABLE;
+
     if (instance != NULL) {
-        reinterpret_cast<DisplayInfo*>(instance)->UnregisterDolbyAudioModeChangedCallback(callback);
+        errorCode = reinterpret_cast<DisplayInfo*>(instance)->UnregisterDolbyAudioModeChangedCallback(callback);
     }
+
+    return errorCode;
 }
 
 void displayinfo_name(struct displayinfo_type* instance, char buffer[], const uint8_t length)

--- a/Source/displayinfo/DisplayInfo.cpp
+++ b/Source/displayinfo/DisplayInfo.cpp
@@ -109,11 +109,9 @@ private:
 
                 if (_displayConnection != nullptr && _hdrProperties == nullptr) {
                     _hdrProperties = _displayConnection->QueryInterface<Exchange::IHDRProperties>();
-                    _hdrProperties->AddRef();
                 }
                 if (_displayConnection != nullptr && _graphicsProperties == nullptr) {
                     _graphicsProperties = _displayConnection->QueryInterface<Exchange::IGraphicsProperties>();
-                    _graphicsProperties->AddRef();
                 }
             }
         } else {

--- a/Source/displayinfo/DisplayInfo.cpp
+++ b/Source/displayinfo/DisplayInfo.cpp
@@ -139,7 +139,7 @@ private:
 
 private:
     //MEMBERS
-    static std::unique_ptr<DisplayInfo> _instance; //in case client forgets to relase the instance
+    static DisplayInfo* _instance;
 
     Exchange::IConnectionProperties* _displayConnection;
     Exchange::IHDRProperties* _hdrProperties;
@@ -160,13 +160,13 @@ public:
     static DisplayInfo* Instance()
     {
         if (_instance == nullptr) {
-            _instance.reset(new DisplayInfo(3000, Connector(), "DisplayInfo")); //no make_unique in C++11 :/
+            _instance = new DisplayInfo(3000, Connector(), "DisplayInfo");
         }
-        return _instance.get();
+        return _instance;
     }
     void DestroyInstance()
     {
-        _instance.reset(nullptr);
+        delete _instance;
     }
 
 public:
@@ -368,7 +368,7 @@ public:
     }
 };
 
-std::unique_ptr<DisplayInfo> DisplayInfo::_instance = nullptr;
+DisplayInfo* DisplayInfo::_instance = nullptr;
 
 } // namespace WPEFramework
 

--- a/Source/displayinfo/display_info/main.c
+++ b/Source/displayinfo/display_info/main.c
@@ -74,10 +74,12 @@ int main(int argc, char* argv[])
                 character = 'Q';
             } else {
                 Trace("Created instance");
-                displayinfo_register_display_output_change_callback(display, displayinfo_display_updated, NULL);
-                Trace("Registered for display upadate events");
-                displayinfo_register_operational_state_change_callback(display, on_operational_state_change, NULL);
-                Trace("Registered for operational state changes of the instance");
+                if (displayinfo_register_display_output_change_callback(display, displayinfo_display_updated, NULL) == 0) {
+                    Trace("Registered for display upadate events");
+                }
+                if (displayinfo_register_operational_state_change_callback(display, on_operational_state_change, NULL) == 0) {
+                    Trace("Registered for operational state changes of the instance");
+                }
             }
 
             break;

--- a/Source/displayinfo/display_info/main.c
+++ b/Source/displayinfo/display_info/main.c
@@ -27,12 +27,9 @@
         fflush(stdout);                                 \
     } while (0)
 
-static uint32_t updatedCount = 0;
-
-static void displayinfo_updated(struct displayinfo_type* session, void* data)
+void displayinfo_display_updated(void* data)
 {
-    updatedCount++;
-    fprintf(stdout, "## %d display updated event%s received.\n", updatedCount, (updatedCount == 1) ? "" : "s");
+    Trace("Display updated callback!\n");
 }
 
 void ShowMenu()
@@ -49,8 +46,6 @@ void ShowMenu()
            "\tT : Get total gpu ram\n"
            "\tF : Get free gpu ram\n"
            "\tX : Get display dimensions in centimeters \n"
-           // "\tR : Enable display info events\n"
-           //"\tU : Disable display info events\n"
            "\t? : Help\n"
            "\tQ : Quit\n");
 }
@@ -74,6 +69,8 @@ int main(int argc, char* argv[])
                 character = 'Q';
             } else {
                 Trace("Created instance");
+                displayinfo_register_display_output_change_callback(display, displayinfo_display_updated, NULL);
+                Trace("Registered for display upadate events");
             }
 
             break;
@@ -234,6 +231,7 @@ int main(int argc, char* argv[])
         }
     } while (character != 'Q');
 
+    displayinfo_unregister_display_output_change_callback(display, displayinfo_display_updated);
     displayinfo_release(display);
 
     Trace("Done");

--- a/Source/displayinfo/display_info/main.c
+++ b/Source/displayinfo/display_info/main.c
@@ -32,6 +32,11 @@ void displayinfo_display_updated(void* data)
     Trace("Display updated callback!\n");
 }
 
+void on_operational_state_change(bool is_operational, void* data)
+{
+    Trace("Operational state of the instance %s operational", is_operational ? "is" : "not");
+}
+
 void ShowMenu()
 {
     printf("Enter\n"
@@ -71,6 +76,8 @@ int main(int argc, char* argv[])
                 Trace("Created instance");
                 displayinfo_register_display_output_change_callback(display, displayinfo_display_updated, NULL);
                 Trace("Registered for display upadate events");
+                displayinfo_register_operational_state_change_callback(display, on_operational_state_change, NULL);
+                Trace("Registered for operational state changes of the instance");
             }
 
             break;
@@ -190,7 +197,7 @@ int main(int argc, char* argv[])
             break;
         }
         case 'E': {
-            //just for testing purposed
+            //just for testing purposes
 
             uint8_t buffer[1000];
             uint16_t length = 1000;
@@ -231,6 +238,7 @@ int main(int argc, char* argv[])
         }
     } while (character != 'Q');
 
+    displayinfo_unregister_operational_state_change_callback(display, on_operational_state_change);
     displayinfo_unregister_display_output_change_callback(display, displayinfo_display_updated);
     displayinfo_release(display);
 

--- a/Source/displayinfo/display_info/main.c
+++ b/Source/displayinfo/display_info/main.c
@@ -38,12 +38,19 @@ static void displayinfo_updated(struct displayinfo_type* session, void* data)
 void ShowMenu()
 {
     printf("Enter\n"
+           "\tI : Get instance.\n"
+           "\tA : Is audio passthru.\n"
            "\tC : Check display connection.\n"
            "\tD : Get current display resolution.\n"
+           "\tV : Get vertical frequency.\n"
            "\tH : Get current HDR standard\n"
            "\tP : Get current HDCP protection\n"
-           "\tR : Enable display info events\n"
-           "\tU : Disable display info events\n"
+           "\tE : Get EDID\n"
+           "\tT : Get total gpu ram\n"
+           "\tF : Get free gpu ram\n"
+           "\tX : Get display dimensions in centimeters \n"
+           // "\tR : Enable display info events\n"
+           //"\tU : Disable display info events\n"
            "\t? : Help\n"
            "\tQ : Quit\n");
 }
@@ -59,92 +66,165 @@ int main(int argc, char* argv[])
         character = toupper(getc(stdin));
 
         switch (character) {
-        case 'L': {
-            uint8_t displayCount = 0;
+        case 'I': {
+            display = displayinfo_instance();
 
-            char instanceName[42];
-            while (displayinfo_enumerate(displayCount++, sizeof(instanceName), instanceName) != false) {
-                printf("DisplayName: %s\n", instanceName);
+            if (display == NULL) {
+                Trace("Exiting: getting interface failed.");
+                character = 'Q';
+            } else {
+                Trace("Created instance");
             }
+
             break;
         }
+        case 'A': {
+            bool is_passthru = false;
+            if (displayinfo_is_audio_passthrough(display, &is_passthru) == 0) {
+                Trace("Audio %s passthrough", is_passthru ? "is" : "is not");
+            } else {
+                Trace("Instance or is_passthru param is NULL, or invalid connection");
+            }
+
+            break;
+        }
+
         case 'C': {
-            Trace("Display %s connected", displayinfo_connected(display) ? "is" : "not");
+            bool is_connected = false;
+            if (displayinfo_is_audio_passthrough(display, &is_connected) == 0) {
+                Trace("Display %s connected", is_connected ? "is" : "is not");
+            } else {
+                Trace("Instance or is_connected param is NULL, or invalid connection");
+            }
+
             break;
         }
         case 'D': {
-            Trace("Display resolution %dhx%dw", displayinfo_height(display), displayinfo_width(display));
+            uint32_t width = 0, height = 0;
+            if (displayinfo_width(display, &width) == 0 && displayinfo_height(display, &height) == 0) {
+                Trace("Display resolution %dhx%dw", width, height);
+            } else {
+                Trace("Instance or width/height param is NULL, or invalid connection");
+            }
+
             break;
         }
+        case 'V': {
+            uint32_t vertical_frequency = 0;
+            if (displayinfo_vertical_frequency(display, &vertical_frequency) == 0) {
+                Trace("Vertical frequency %d", vertical_frequency);
+            } else {
+                Trace("Instance or vertical_frequency is NULL, or invalid connection");
+            }
+
+            break;
+        }
+
         case 'H': {
-            switch (displayinfo_hdr(display)) {
-            case DISPLAYINFO_HDR_OFF: {
-                Trace("HDR: OFF");
-                break;
-            }
-            case DISPLAYINFO_HDR_10: {
-                Trace("HDR: HDR10");
-                break;
-            }
-            case DISPLAYINFO_HDR_10PLUS: {
-                Trace("HDR: HDR10 Plus");
-                break;
-            }
-            case DISPLAYINFO_HDR_DOLBYVISION: {
-                Trace("HDR: DolbyVision");
-                break;
-            }
-            case DISPLAYINFO_HDR_TECHNICOLOR: {
-                Trace("HDR: Technicolor");
-                break;
-            }
-            default: {
-                Trace("HDR: Unknown");
-                break;
-            }
+            displayinfo_hdr_t hdr;
+
+            if (displayinfo_hdr(display, &hdr) != 0) {
+                Trace("Instance or hdr param is null or invalid connection");
+            } else {
+
+                switch (hdr) {
+                case DISPLAYINFO_HDR_OFF: {
+                    Trace("HDR: OFF");
+                    break;
+                }
+                case DISPLAYINFO_HDR_10: {
+                    Trace("HDR: HDR10");
+                    break;
+                }
+                case DISPLAYINFO_HDR_10PLUS: {
+                    Trace("HDR: HDR10 Plus");
+                    break;
+                }
+                case DISPLAYINFO_HDR_DOLBYVISION: {
+                    Trace("HDR: DolbyVision");
+                    break;
+                }
+                case DISPLAYINFO_HDR_TECHNICOLOR: {
+                    Trace("HDR: Technicolor");
+                    break;
+                }
+                default: {
+                    Trace("HDR: Unknown");
+                    break;
+                }
+                }
             }
             break;
         }
         case 'P': {
-            switch (displayinfo_hdcp_protection(display)) {
-            case DISPLAYINFO_HDCP_UNENCRYPTED: {
-                Trace("HDCP: Unencrypted");
-                break;
-            }
-            case DISPLAYINFO_HDCP_1X: {
-                Trace("HDCP: 1.x Enabled");
-                break;
-            }
-            case DISPLAYINFO_HDCP_2X: {
-                Trace("HDCP: 2.x Enabled");
-                break;
-            }
-            default: {
-                Trace("HDCP: Unknown");
-                break;
-            }
-            }
-            break;
-        }
-        case 'R': {
-            displayinfo_register(display, displayinfo_updated, NULL);
-            Trace("Display events enabled");
-            break;
-        }
-        case 'U': {
-            displayinfo_unregister(display, displayinfo_updated);
-            Trace("Display events disabled");
-            break;
-        }
-        case 'Z': {
-            display = displayinfo_instance("DisplayInfo");
+            displayinfo_hdcp_protection_t hdcp;
 
-            if (display == NULL) {
-                Trace("Exiting: getting interface for failed.");
+            if (displayinfo_hdcp_protection(display, &hdcp) != 0) {
+                Trace("Instance or hdcp param is null or invalid connection");
+            } else {
+                switch (hdcp) {
+                case DISPLAYINFO_HDCP_UNENCRYPTED: {
+                    Trace("HDCP: Unencrypted");
+                    break;
+                }
+                case DISPLAYINFO_HDCP_1X: {
+                    Trace("HDCP: 1.x Enabled");
+                    break;
+                }
+                case DISPLAYINFO_HDCP_2X: {
+                    Trace("HDCP: 2.x Enabled");
+                    break;
+                }
+                default: {
+                    Trace("HDCP: Unknown");
+                    break;
+                }
+                }
             }
-
             break;
         }
+        case 'T': {
+            uint64_t total_ram = 0;
+            if (displayinfo_total_gpu_ram(display, &total_ram) == 0) {
+                Trace("Total ram: %lld", total_ram);
+            } else {
+                Trace("Instance or total_ram is NULL, or invalid connection");
+            }
+            break;
+        }
+        case 'E': {
+            //just for testing purposed
+
+            uint8_t buffer[1000];
+            uint16_t length = 1000;
+            if (displayinfo_edid(display, buffer, &length) == 0) {
+                Trace("Length: %d", length);
+                Trace("EDID: %s", buffer);
+            } else {
+                Trace("Instance or buffer or length is NULL, or invalid connection");
+            }
+            break;
+        }
+
+        case 'F': {
+            uint64_t free_ram = 0;
+            if (displayinfo_free_gpu_ram(display, &free_ram) == 0) {
+                Trace("Free ram: %lld", free_ram);
+            } else {
+                Trace("Instance or free_ram is NULL, or invalid connection");
+            }
+            break;
+        }
+        case 'X': {
+            uint8_t width = 0, height = 0;
+            if (displayinfo_width_in_centimeters(display, &width) == 0 && displayinfo_height_in_centimeters(display, &height) == 0) {
+                Trace("Display dimension in cm: %dhx%dw", width, height);
+            } else {
+                Trace("Instance or width/height param is NULL, or invalid connection");
+            }
+            break;
+        }
+
         case '?': {
             ShowMenu();
             break;

--- a/Source/displayinfo/include/displayinfo.h
+++ b/Source/displayinfo/include/displayinfo.h
@@ -31,7 +31,7 @@
 #pragma comment(lib, "displayinfo.lib")
 #endif
 #else
-#define EXTERNAL __attribute__ ((visibility ("default")))
+#define EXTERNAL __attribute__((visibility("default")))
 #endif
 
 #ifdef __cplusplus
@@ -55,11 +55,13 @@ typedef enum displayinfo_hdcp_protection_type {
     DISPLAYINFO_HDCP_UNKNOWN
 } displayinfo_hdcp_protection_t;
 
+/* Where is this needed?
 typedef enum displayinfo_error_type {
     DISPLAYINFO_ERROR_NONE = 0,
     DISPLAYINFO_ERROR_UNKNOWN = 1,
     DISPLAYINFO_ERROR_INVALID_INSTANCE = 2,
 } displayinfo_error_t;
+*/
 
 /**
 * \brief Will be called if there are changes regaring the display output, you need to query 
@@ -70,17 +72,6 @@ typedef enum displayinfo_error_type {
 */
 typedef void (*displayinfo_updated_cb)(struct displayinfo_type* session, void* userdata);
 
-/**
- * \brief Get a implementation instance name to use for displayinfo_instance based on index\
- *        If \ref length is 0  and \ref buffer is NULL, only a check is assumed.
- * 
- * \param index The index of a DisplayInfo implementation
- * \param length Length \ref buffer, can be 0 for a check only
- * \param buffer Pointer to a buffer, can be NULL if \ref length is 0 for a check only
- * 
- * \return true if a instance was found for the index, false otherwise.
- **/
-EXTERNAL bool displayinfo_enumerate(const uint8_t index, const uint8_t length, char* buffer);
 
 /**
  * \brief Get a \ref displayinfo_type instance that matches the a DisplayInfo implementation.
@@ -89,7 +80,7 @@ EXTERNAL bool displayinfo_enumerate(const uint8_t index, const uint8_t length, c
  * 
  * \return \ref displayinfo_type instance, NULL on error.
  **/
-EXTERNAL struct displayinfo_type* displayinfo_instance(const char displayName[]);
+EXTERNAL struct displayinfo_type* displayinfo_instance();
 
 /**
  * \brief Release the \ref displayinfo_type instance.
@@ -107,7 +98,7 @@ EXTERNAL void displayinfo_release(struct displayinfo_type* instance);
  * \param userdata The user data to be passed back to the \ref displayinfo_updated_cb callback.
  * 
  **/
-EXTERNAL void displayinfo_register(struct displayinfo_type* instance, displayinfo_updated_cb callback, void* userdata);
+//EXTERNAL void displayinfo_register(struct displayinfo_type* instance, displayinfo_updated_cb callback, void* userdata);
 
 /**
  * \brief Unregister for updates of the display output.
@@ -116,7 +107,7 @@ EXTERNAL void displayinfo_register(struct displayinfo_type* instance, displayinf
  * \param callback Callback that was used to \ref displayinfo_registet
  * 
  **/
-EXTERNAL void displayinfo_unregister(struct displayinfo_type* instance, displayinfo_updated_cb callback);
+//EXTERNAL void displayinfo_unregister(struct displayinfo_type* instance, displayinfo_updated_cb callback);
 
 /**
  * \brief Returns name of display output.
@@ -135,7 +126,7 @@ EXTERNAL void displayinfo_name(struct displayinfo_type* instance, char buffer[],
  * 
  * \return true if audio passthrough is enabled, false otherwise.
  **/
-EXTERNAL bool displayinfo_is_audio_passthrough(struct displayinfo_type* instance);
+EXTERNAL uint32_t displayinfo_is_audio_passthrough(struct displayinfo_type* instance, bool* is_passthrough);
 
 /**
  * \brief Checks if a display is connected to the display output.
@@ -145,7 +136,7 @@ EXTERNAL bool displayinfo_is_audio_passthrough(struct displayinfo_type* instance
  * \return true a dispplay is connected, false otherwise.
  * 
  **/
-EXTERNAL bool displayinfo_connected(struct displayinfo_type* instance);
+EXTERNAL uint32_t displayinfo_connected(struct displayinfo_type* instance, bool* is_connected);
 
 /**
  * \brief Get the heigth of the connected display  
@@ -155,7 +146,7 @@ EXTERNAL bool displayinfo_connected(struct displayinfo_type* instance);
  * \return The current heigth in pixels, 0 on error or invalid connection
  * 
  **/
-EXTERNAL uint32_t displayinfo_width(struct displayinfo_type* instance);
+EXTERNAL uint32_t displayinfo_width(struct displayinfo_type* instance, uint32_t* width);
 
 /**
  * \brief Get the width of the connected display  
@@ -165,7 +156,7 @@ EXTERNAL uint32_t displayinfo_width(struct displayinfo_type* instance);
  * \return The current width in pixels, 0 on error or invalid connection
  *
  **/
-EXTERNAL uint32_t displayinfo_height(struct displayinfo_type* instance);
+EXTERNAL uint32_t displayinfo_height(struct displayinfo_type* instance, uint32_t* height);
 
 /**
  * \brief Get the vertical refresh rate ("v-sync")  
@@ -175,7 +166,7 @@ EXTERNAL uint32_t displayinfo_height(struct displayinfo_type* instance);
  * \return The vertical refresh rate
  *
  **/
-EXTERNAL uint32_t displayinfo_vertical_frequency(struct displayinfo_type* instance);
+EXTERNAL uint32_t displayinfo_vertical_frequency(struct displayinfo_type* instance, uint32_t* vertical_freq);
 
 /**
  * \brief Get the current HDR system of the connected display  
@@ -185,7 +176,7 @@ EXTERNAL uint32_t displayinfo_vertical_frequency(struct displayinfo_type* instan
  * \return The current enabled HDR system, DISPLAYINFO_HDR_UNKNOWN on error or invalid connection
  * 
  **/
-EXTERNAL displayinfo_hdr_t displayinfo_hdr(struct displayinfo_type* instance);
+EXTERNAL uint32_t displayinfo_hdr(struct displayinfo_type* instance, displayinfo_hdr_t* hdr);
 
 /**
  * \brief Get the current HDCP protection level of the connected display  
@@ -195,7 +186,7 @@ EXTERNAL displayinfo_hdr_t displayinfo_hdr(struct displayinfo_type* instance);
  * \return The current enabled HDCP level, DISPLAYINFO_HDCP_UNKNOWN on error or invalid connection
  * 
  **/
-EXTERNAL displayinfo_hdcp_protection_t displayinfo_hdcp_protection(struct displayinfo_type* instance);
+EXTERNAL uint32_t displayinfo_hdcp_protection(struct displayinfo_type* instance, displayinfo_hdcp_protection_t* hdcp);
 
 /**
  * \brief Get the total available GPU RAM space in bytes.
@@ -203,7 +194,7 @@ EXTERNAL displayinfo_hdcp_protection_t displayinfo_hdcp_protection(struct displa
  * \param instance Instance of \ref displayinfo_type.
  * \return The total amount of GPU RAM available on the device.
  */
-EXTERNAL uint64_t displayinfo_total_gpu_ram(struct displayinfo_type* instance);
+EXTERNAL uint32_t displayinfo_total_gpu_ram(struct displayinfo_type* instance, uint64_t* total_ram);
 
 /**
  * \brief Get the currently available GPU RAM in bytes.
@@ -211,7 +202,7 @@ EXTERNAL uint64_t displayinfo_total_gpu_ram(struct displayinfo_type* instance);
  * \param instance Instance of \ref displayinfo_type.
  * \return The current amount of available GPU RAM memory.
  */
-EXTERNAL uint64_t displayinfo_free_gpu_ram(struct displayinfo_type* instance);
+EXTERNAL uint32_t displayinfo_free_gpu_ram(struct displayinfo_type* instance, uint64_t* free_ram);
 
 /**
  * \brief Returns EDID data of a connected display.
@@ -231,7 +222,7 @@ EXTERNAL uint32_t displayinfo_edid(struct displayinfo_type* instance, uint8_t bu
  * \return The current heigth in centimeters, 0 on error or invalid connection
  *
  **/
-EXTERNAL uint8_t displayinfo_width_in_centimeters(struct displayinfo_type* instance);
+EXTERNAL uint32_t displayinfo_width_in_centimeters(struct displayinfo_type* instance, uint8_t* width);
 
 /**
  * \brief Get the width of the connected display in centimeters
@@ -241,7 +232,7 @@ EXTERNAL uint8_t displayinfo_width_in_centimeters(struct displayinfo_type* insta
  * \return The current width in centimeters, 0 on error or invalid connection
  *
  **/
-EXTERNAL uint8_t displayinfo_height_in_centimeters(struct displayinfo_type* instance);
+EXTERNAL uint32_t displayinfo_height_in_centimeters(struct displayinfo_type* instance, uint8_t* height);
 
 /**
  * \brief Checks if Dolby ATMOS is enabled.

--- a/Source/displayinfo/include/displayinfo.h
+++ b/Source/displayinfo/include/displayinfo.h
@@ -104,8 +104,11 @@ EXTERNAL void displayinfo_release(struct displayinfo_type* instance);
  * @param instance Instance of displayinfo_type
  * @param callback Function to be called on update
  * @param userdata Data passed to callback function
+ * @return ERROR_NONE on succes, 
+ *         ERROR_GENERAL if callback already registered 
+ *         ERROR_UNAVAILABLE if: instance or is NULL
  */
-EXTERNAL void displayinfo_register_operational_state_change_callback(struct displayinfo_type* instance,
+EXTERNAL uint32_t displayinfo_register_operational_state_change_callback(struct displayinfo_type* instance,
     displayinfo_operational_state_change_cb callback,
     void* userdata);
 /**
@@ -113,8 +116,11 @@ EXTERNAL void displayinfo_register_operational_state_change_callback(struct disp
  * 
  * @param instance Instance of displayinfo_type
  * @param callback Function to be unregistered from callbacks
+ * @return ERROR_NONE on succes, 
+ *         ERROR_NOT_EXIST if callback not registered
+ *         ERROR_UNAVAILABLE if: instance or is NULL
  */
-EXTERNAL void displayinfo_unregister_operational_state_change_callback(struct displayinfo_type* instance,
+EXTERNAL uint32_t displayinfo_unregister_operational_state_change_callback(struct displayinfo_type* instance,
     displayinfo_operational_state_change_cb callback);
 
 /**
@@ -123,18 +129,22 @@ EXTERNAL void displayinfo_unregister_operational_state_change_callback(struct di
  * @param instance Instance of @ref displayinfo_type.
  * @param callback Callback that needs to be called if a chaged is deteced.
  * @param userdata The user data to be passed back to the @ref displayinfo_updated_cb callback.
- * 
+ * @return ERROR_NONE on succes, 
+ *         ERROR_GENERAL if callback already registered 
+ *         ERROR_UNAVAILABLE if: instance or is NULL
  **/
-EXTERNAL void displayinfo_register_display_output_change_callback(struct displayinfo_type* instance, displayinfo_display_output_change_cb callback, void* userdata);
+EXTERNAL uint32_t displayinfo_register_display_output_change_callback(struct displayinfo_type* instance, displayinfo_display_output_change_cb callback, void* userdata);
 
 /**
  * @brief Unregister for updates of the display output.
  * 
  * @param instance Instance of @ref displayinfo_type.
  * @param callback Callback that was used to @ref displayinfo_registet
- * 
+ * @return ERROR_NONE on succes, 
+ *         ERROR_NOT_EXIST if callback not registered
+ *         ERROR_UNAVAILABLE if: instance or is NULL
  **/
-EXTERNAL void displayinfo_unregister_display_output_change_callback(struct displayinfo_type* instance, displayinfo_display_output_change_cb callback);
+EXTERNAL uint32_t displayinfo_unregister_display_output_change_callback(struct displayinfo_type* instance, displayinfo_display_output_change_cb callback);
 
 /**
  * @brief Returns name of display output.

--- a/Source/displayinfo/include/displayinfo.h
+++ b/Source/displayinfo/include/displayinfo.h
@@ -64,6 +64,18 @@ typedef enum displayinfo_error_type {
 */
 
 /**
+* @brief Will be called if there are changes regarding operational state of the
+*        instance - if it is not operational that means any function calls using it 
+*        will not succeed (will return Core::ERROR_UNAVAILABLE). Not operational state 
+*        can occur if the plugin inside WPEFramework has been deactivated.
+*
+*
+* @param userData Pointer passed along when @ref displayinfo_register was issued.
+* @param is_operational If instance is operational or not
+*/
+typedef void (*displayinfo_operational_state_change_cb)(bool is_operational, void* userdata);
+
+/**
 * \brief Will be called if there are changes regaring the display output, you need to query 
 *        yourself what exacally is changed
 *
@@ -87,6 +99,25 @@ EXTERNAL struct displayinfo_type* displayinfo_instance();
  * 
  **/
 EXTERNAL void displayinfo_release(struct displayinfo_type* instance);
+
+/**
+ * @brief Register for the operational state change notification of the instance
+ * 
+ * @param instance Instance of displayinfo_type
+ * @param callback Function to be called on update
+ * @param userdata Data passed to callback function
+ */
+EXTERNAL void displayinfo_register_operational_state_change_callback(struct displayinfo_type* instance,
+    displayinfo_operational_state_change_cb callback,
+    void* userdata);
+/**
+ * @brief Unregister from the operational state change notification of the instance
+ * 
+ * @param instance Instance of displayinfo_type
+ * @param callback Function to be unregistered from callbacks
+ */
+EXTERNAL void displayinfo_unregister_operational_state_change_callback(struct displayinfo_type* instance,
+    displayinfo_operational_state_change_cb callback);
 
 /**
  * \brief Register for updates of the display output.

--- a/Source/displayinfo/include/displayinfo.h
+++ b/Source/displayinfo/include/displayinfo.h
@@ -67,11 +67,9 @@ typedef enum displayinfo_error_type {
 * \brief Will be called if there are changes regaring the display output, you need to query 
 *        yourself what exacally is changed
 *
-* \param session The session the notification applies to.
 * \param userData Pointer passed along when \ref displayinfo_register was issued.
 */
-typedef void (*displayinfo_updated_cb)(struct displayinfo_type* session, void* userdata);
-
+typedef void (*displayinfo_display_output_change_cb)(void* userdata);
 
 /**
  * \brief Get a \ref displayinfo_type instance that matches the a DisplayInfo implementation.
@@ -98,7 +96,7 @@ EXTERNAL void displayinfo_release(struct displayinfo_type* instance);
  * \param userdata The user data to be passed back to the \ref displayinfo_updated_cb callback.
  * 
  **/
-//EXTERNAL void displayinfo_register(struct displayinfo_type* instance, displayinfo_updated_cb callback, void* userdata);
+EXTERNAL void displayinfo_register_display_output_change_callback(struct displayinfo_type* instance, displayinfo_display_output_change_cb callback, void* userdata);
 
 /**
  * \brief Unregister for updates of the display output.
@@ -107,7 +105,7 @@ EXTERNAL void displayinfo_release(struct displayinfo_type* instance);
  * \param callback Callback that was used to \ref displayinfo_registet
  * 
  **/
-//EXTERNAL void displayinfo_unregister(struct displayinfo_type* instance, displayinfo_updated_cb callback);
+EXTERNAL void displayinfo_unregister_display_output_change_callback(struct displayinfo_type* instance, displayinfo_display_output_change_cb callback);
 
 /**
  * \brief Returns name of display output.

--- a/Source/displayinfo/include/displayinfo.h
+++ b/Source/displayinfo/include/displayinfo.h
@@ -76,26 +76,24 @@ typedef enum displayinfo_error_type {
 typedef void (*displayinfo_operational_state_change_cb)(bool is_operational, void* userdata);
 
 /**
-* \brief Will be called if there are changes regaring the display output, you need to query 
+* @brief Will be called if there are changes regaring the display output, you need to query 
 *        yourself what exacally is changed
 *
-* \param userData Pointer passed along when \ref displayinfo_register was issued.
+* @param userData Pointer passed along when \ref displayinfo_register was issued.
 */
 typedef void (*displayinfo_display_output_change_cb)(void* userdata);
 
 /**
- * \brief Get a \ref displayinfo_type instance that matches the a DisplayInfo implementation.
- *
- * \param displayName Name a the implementation that holds the.
+ * @brief Get a @ref displayinfo_type instance that matches the a DisplayInfo implementation.
  * 
- * \return \ref displayinfo_type instance, NULL on error.
+ * @return @ref displayinfo_type instance, NULL on error.
  **/
 EXTERNAL struct displayinfo_type* displayinfo_instance();
 
 /**
- * \brief Release the \ref displayinfo_type instance.
+ * @brief Release the @ref displayinfo_type instance.
  * 
- * \param instance Instance of \ref displayinfo_type.
+ * @param instance Instance of ref displayinfo_type.
  * 
  **/
 EXTERNAL void displayinfo_release(struct displayinfo_type* instance);
@@ -120,156 +118,165 @@ EXTERNAL void displayinfo_unregister_operational_state_change_callback(struct di
     displayinfo_operational_state_change_cb callback);
 
 /**
- * \brief Register for updates of the display output.
+ * @brief Register for updates of the display output.
  * 
- * \param instance Instance of \ref displayinfo_type.
- * \param callback Callback that needs to be called if a chaged is deteced.
- * \param userdata The user data to be passed back to the \ref displayinfo_updated_cb callback.
+ * @param instance Instance of @ref displayinfo_type.
+ * @param callback Callback that needs to be called if a chaged is deteced.
+ * @param userdata The user data to be passed back to the @ref displayinfo_updated_cb callback.
  * 
  **/
 EXTERNAL void displayinfo_register_display_output_change_callback(struct displayinfo_type* instance, displayinfo_display_output_change_cb callback, void* userdata);
 
 /**
- * \brief Unregister for updates of the display output.
+ * @brief Unregister for updates of the display output.
  * 
- * \param instance Instance of \ref displayinfo_type.
- * \param callback Callback that was used to \ref displayinfo_registet
+ * @param instance Instance of @ref displayinfo_type.
+ * @param callback Callback that was used to @ref displayinfo_registet
  * 
  **/
 EXTERNAL void displayinfo_unregister_display_output_change_callback(struct displayinfo_type* instance, displayinfo_display_output_change_cb callback);
 
 /**
- * \brief Returns name of display output.
+ * @brief Returns name of display output.
  *
- * \param instance Instance of \ref displayinfo_type.
- * \param buffer Buffer that will contain instance name.
- * \param length Size of \ref buffer.
+ * @param instance Instance of @ref displayinfo_type.
+ * @param buffer Buffer that will contain instance name.
+ * @param length Size of @ref buffer.
  *
  **/
 EXTERNAL void displayinfo_name(struct displayinfo_type* instance, char buffer[], const uint8_t length);
 
 /**
- * \brief Checks if a audio passthrough is enabled.
+ * @brief Checks if a audio passthrough is enabled.
  * 
- * \param instance Instance of \ref displayinfo_type.
- * 
- * \return true if audio passthrough is enabled, false otherwise.
- **/
+ * @param instance instance of @ref displayinfo_type
+ * @param is_passthrough true if audio passthrough is enabled, false otherwise
+ * @return ERROR_NONE on succes,
+ *         ERROR_UNAVAILABLE if instance or is_enabled param is NULL or invalid connection
+ */
 EXTERNAL uint32_t displayinfo_is_audio_passthrough(struct displayinfo_type* instance, bool* is_passthrough);
 
 /**
- * \brief Checks if a display is connected to the display output.
+ * @brief Checks if a display is connected to the display output.
  * 
- * \param instance Instance of \ref displayinfo_type.
- * 
- * \return true a dispplay is connected, false otherwise.
- * 
- **/
+ * @param instance Instance of @ref displayinfo_type
+ * @param is_connected  true a dispplay is connected, false otherwise.
+ * @return ERROR_NONE on succes,
+ *         ERROR_UNAVAILABLE if instance or is_enabled param is NULL or invalid connection
+ */
 EXTERNAL uint32_t displayinfo_connected(struct displayinfo_type* instance, bool* is_connected);
 
 /**
- * \brief Get the heigth of the connected display  
+ * @brief Get the width of the connected display  
  * 
- * \param instance Instance of \ref displayinfo_type.
- * 
- * \return The current heigth in pixels, 0 on error or invalid connection
- * 
- **/
+ * @param instance Instance of @ref displayinfo_type
+ * @param width The current width in pixels
+ * @return ERROR_NONE on succes,
+ *         ERROR_UNAVAILABLE if instance or is_enabled param is NULL or invalid connection
+ */
 EXTERNAL uint32_t displayinfo_width(struct displayinfo_type* instance, uint32_t* width);
 
 /**
- * \brief Get the width of the connected display  
+ * @brief Get the height of the connected display  
  * 
- * \param instance Instance of \ref displayinfo_type.
- * 
- * \return The current width in pixels, 0 on error or invalid connection
- *
- **/
+ * @param instance Instance of @ref displayinfo_type
+ * @param width The current height in pixels
+ * @return ERROR_NONE on succes,
+ *         ERROR_UNAVAILABLE if instance or is_enabled param is NULL or invalid connection
+ */
 EXTERNAL uint32_t displayinfo_height(struct displayinfo_type* instance, uint32_t* height);
 
 /**
- * \brief Get the vertical refresh rate ("v-sync")  
+ * @brief Get the vertical refresh rate ("v-sync")  
  * 
- * \param instance Instance of \ref displayinfo_type.
- * 
- * \return The vertical refresh rate
- *
- **/
+ * @param instance Instance of @ref displayinfo_type
+ * @param vertical_freq The vertical refresh rate
+ * @return ERROR_NONE on succes,
+ *         ERROR_UNAVAILABLE if instance or is_enabled param is NULL or invalid connection
+ */
 EXTERNAL uint32_t displayinfo_vertical_frequency(struct displayinfo_type* instance, uint32_t* vertical_freq);
 
 /**
- * \brief Get the current HDR system of the connected display  
+ * @brief Get the current HDR system of the connected display  
  * 
- * \param instance Instance of \ref displayinfo_type.
- * 
- * \return The current enabled HDR system, DISPLAYINFO_HDR_UNKNOWN on error or invalid connection
- * 
- **/
+ * @param instance Instance of @ref displayinfo_type
+ * @param hdr The current enabled HDR system, DISPLAYINFO_HDR_UNKNOWN might occur if ThunderInterfaces contains new 
+ *            entry not defined in this client library
+ * @return ERROR_NONE on succes, 
+ *         ERROR_UNKNOWN_KEY if: ThunderInterfaces contains new hdr type not defined in this library 
+ *         ERROR_UNAVAILABLE if: instance or hdr param is NULL or invalid connection
+ */
 EXTERNAL uint32_t displayinfo_hdr(struct displayinfo_type* instance, displayinfo_hdr_t* hdr);
 
 /**
- * \brief Get the current HDCP protection level of the connected display  
+ * @brief Get the current HDCP protection level of the connected display  
  * 
- * \param instance Instance of \ref displayinfo_type.
- * 
- * \return The current enabled HDCP level, DISPLAYINFO_HDCP_UNKNOWN on error or invalid connection
- * 
- **/
+ * @param instance Instance of @ref displayinfo_type
+ * @param hdcp The current enabled HDCP level, DISPLAYINFO_HDCP_UNKNOWN might occur if Thunder interfaces contains new
+ *              entry not defined in client library
+ * @return ERROR_NONE on succes, 
+ *         ERROR_UNKNOWN_KEY if: ThunderInterfaces contains new hdcp protection type not defined in this library 
+ *         ERROR_UNAVAILABLE if: instance or hdr param is NULL or invalid connection
+ */
 EXTERNAL uint32_t displayinfo_hdcp_protection(struct displayinfo_type* instance, displayinfo_hdcp_protection_t* hdcp);
 
 /**
- * \brief Get the total available GPU RAM space in bytes.
+ * @brief Get the total available GPU RAM space in bytes.
  * 
- * \param instance Instance of \ref displayinfo_type.
- * \return The total amount of GPU RAM available on the device.
+ * @param instance Instance of @ref displayinfo_type
+ * @param total_ram The total amount of GPU RAM available on the device.
+ * @return ERROR_NONE on succes,
+ *         ERROR_UNAVAILABLE if instance or total_ram param is NULL or invalid connection  
  */
 EXTERNAL uint32_t displayinfo_total_gpu_ram(struct displayinfo_type* instance, uint64_t* total_ram);
 
 /**
- * \brief Get the currently available GPU RAM in bytes.
+ * @brief Get the free available GPU RAM space in bytes.
  * 
- * \param instance Instance of \ref displayinfo_type.
- * \return The current amount of available GPU RAM memory.
+ * @param instance Instance of @ref displayinfo_type
+ * @param free_ram The total amount of GPU RAM available on the device.
+ * @return ERROR_NONE on succes,
+ *         ERROR_UNAVAILABLE if instance or free_ram param is NULL or invalid connection
  */
 EXTERNAL uint32_t displayinfo_free_gpu_ram(struct displayinfo_type* instance, uint64_t* free_ram);
 
 /**
- * \brief Returns EDID data of a connected display.
- *
- * \param instance Instance of \ref displayinfo_type.
- * \param buffer Buffer that will contain the data.
- * \param length Size of \ref buffer. On success it'll be set to the length of the actuall data in \ref buffer.
- *
- **/
+ * @brief Returns EDID data of a connected display.
+ * 
+ * @param instance Instance of @ref displayinfo_type
+ * @param buffer Buffer that will contain the data.
+ * @param length Size of @ref buffer. On success it'll be set to the length of the actuall data in @ref buffer.
+ * @return  ERROR_NONE on succes,
+ *         ERROR_UNAVAILABLE if instance or free_ram param is NULL or invalid connection
+ */
 EXTERNAL uint32_t displayinfo_edid(struct displayinfo_type* instance, uint8_t buffer[], uint16_t* length);
 
 /**
- * \brief Get the heigth of the connected display in centimaters
- *
- * \param instance Instance of \ref displayinfo_type.
- *
- * \return The current heigth in centimeters, 0 on error or invalid connection
- *
- **/
+ * @brief Get the width of the connected display in centimaters
+ * 
+ * @param instance Instance of @ref displayinfo_type
+ * @param width The current width in centimeters
+ * @return ERROR_NONE on succes,
+ *         ERROR_UNAVAILABLE if instance or width param is NULL or invalid connection 
+ */
 EXTERNAL uint32_t displayinfo_width_in_centimeters(struct displayinfo_type* instance, uint8_t* width);
 
 /**
- * \brief Get the width of the connected display in centimeters
- *
- * \param instance Instance of \ref displayinfo_type.
- *
- * \return The current width in centimeters, 0 on error or invalid connection
- *
- **/
+ * @brief Get the heigth of the connected display in centimaters
+ * 
+ * @param instance Instance of @ref displayinfo_type
+ * @param height The current height in centimeters
+ * @return ERROR_NONE on succes,
+ *         ERROR_UNAVAILABLE if instance or height param is NULL or invalid connection 
+ */
 EXTERNAL uint32_t displayinfo_height_in_centimeters(struct displayinfo_type* instance, uint8_t* height);
 
 /**
- * \brief Checks if Dolby ATMOS is enabled.
- *
- * \param instance Instance of \ref displayinfo_type.
- *
- * \return true if Dolby ATMOS is enabled, false otherwise.
- **/
+ * @brief Checks if Dolby ATMOS is enabled.
+ * 
+ * @param instance Instance of @ref displayinfo_type.
+ * @return true if Dolby ATMOS is enabled, false otherwise.
+ */
 EXTERNAL bool displayinfo_is_atmos_supported(struct displayinfo_type* instance);
 
 #ifdef __cplusplus


### PR DESCRIPTION
Used SmartInterfaceType so that upon plugin deactivation the retrieved instance is in a nonoperational state, meaning that any function call inside the client app will not succeed. Upon activation, in the implementation, the new interface will be accessed. The client however always has the valid pointer, which points to the implementation class. 

Added functionality of callbacks when instance changes its operational state. Renamed register and unregister methods for a callback so they easily differ.

Functions now return uint32_t, which is used for returning Core::Errors. Result parameters are retrieved via pointer argument.
