### PR TITLE
SecApi/Cipher.cpp: add missing ';' in ASSERT() call

### DIFF
--- a/Source/cryptography/implementation/SecApi/Cipher.cpp
+++ b/Source/cryptography/implementation/SecApi/Cipher.cpp
@@ -41,7 +41,7 @@ namespace Implementation {
         ASSERT(vault != nullptr);
         ASSERT(keyId != 0);
         ASSERT(keyLength != 0);
-        ASSERT(ivLength != 0)
+        ASSERT(ivLength != 0);
 
     }
 

--- a/Source/cryptography/implementation/SecApi/CipherNetflix.cpp
+++ b/Source/cryptography/implementation/SecApi/CipherNetflix.cpp
@@ -117,7 +117,7 @@ namespace Implementation {
 
         if (inputLength % AES_128_BLOCK_SIZE != 0) {
             outputbuf.resize(inputLength + (AES_128_BLOCK_SIZE - (inputLength % AES_128_BLOCK_SIZE)));
-            TRACE_L2(_T("SecNetflix_Aescbc adding pad to output buffer %d\n", outputbuf.size()));
+            TRACE_L2(_T("SecNetflix_Aescbc adding pad to output buffer %d\n"), outputbuf.size());
         }
         else {
             outputbuf.resize(inputLength + AES_128_BLOCK_SIZE);
@@ -131,14 +131,14 @@ namespace Implementation {
                 input, inputLength, out_buf, outputbuf.size(), &bytesWritten);
 
             if (result != SEC_RESULT_SUCCESS) {
-                TRACE_L1(_T("SecNetflix_Aescbc FAILED : retVal = %d\n", result));
+                TRACE_L1(_T("SecNetflix_Aescbc FAILED : retVal = %d\n"), result);
             }
         }
         else {
-            TRACE_L1(_T("FindKey did not find key handle = %d\n", keyHandle));
+            TRACE_L1(_T("FindKey did not find key handle = %d\n"), keyHandle);
         }
 
-        TRACE_L2(_T("Encrypted message: encdatalen=%u\n", bytesWritten));
+        TRACE_L2(_T("Encrypted message: encdatalen=%u\n"), bytesWritten);
         memcpy(output, out_buf, bytesWritten);
         retVal = bytesWritten;
 

--- a/Source/cryptography/implementation/SecApi/DiffieHellman.cpp
+++ b/Source/cryptography/implementation/SecApi/DiffieHellman.cpp
@@ -124,7 +124,7 @@ namespace Implementation {
                 hmacKeyId = _vault->AddKey(hKeyHMAC);
                 wrappingKeyId = _vault->AddKey(hKeyWrap);
                 result = RET_OK;
-                TRACE_L2(_T("SEC:Netflix Derive  enc %d  hmac %d  wrapping handle %d \n", encryptionKeyId, hmacKeyId, wrappingKeyId));
+                TRACE_L2(_T("SEC:Netflix Derive  enc %d  hmac %d  wrapping handle %d \n"), encryptionKeyId, hmacKeyId, wrappingKeyId);
             }
             else {
                 TRACE_L1(_T("SEC:SecNetflix_NetflixDHDerive failed ,retval = %d \n"),result_sec);


### PR DESCRIPTION
Missing semicolon causes SecApi/Cipher.cpp to fail to compile when
debug build is enabled. On release there is no problem as ASSERT()
evaluates to nothing and thus semicolon is not really needed.

Signed-off-by: Michał Łyszczek <michal.lyszczek@consult.red>