### PR TITLE
DELIA-49951 DELIA-49978: add locking

### DIFF
--- a/Source/securityagent/CMakeLists.txt
+++ b/Source/securityagent/CMakeLists.txt
@@ -34,6 +34,7 @@ find_package(${NAMESPACE}Core REQUIRED)
 add_library(${TARGET} SHARED
         ipclink.cpp
         Module.cpp
+        filelock.cpp
         )
 
 set(PUBLIC_HEADERS

--- a/Source/securityagent/filelock.cpp
+++ b/Source/securityagent/filelock.cpp
@@ -1,0 +1,32 @@
+#include "filelock.h"
+
+#include <sys/file.h>
+#include <unistd.h>
+
+FileLock::Lock::Lock(FileLock* sem)
+    : ptr(sem)
+    , locked(false) {
+    locked = ptr->Wait();
+}
+
+FileLock::Lock::~Lock() {
+    if (locked) {
+        ptr->Unlock();
+    }
+}
+
+FileLock::FileLock(const char* name) {
+    fd_lock = open(name, O_CREAT, S_IRUSR | S_IWUSR);
+}
+
+FileLock::~FileLock() {
+    close(fd_lock);
+}
+
+bool FileLock::Wait() {
+    return (flock(fd_lock, LOCK_EX) == 0);
+}
+
+bool FileLock::Unlock() {
+    return (flock(fd_lock, LOCK_UN) == 0);
+}

--- a/Source/securityagent/filelock.h
+++ b/Source/securityagent/filelock.h
@@ -1,0 +1,30 @@
+#ifndef FILE_LOCK_H
+#define FILE_LOCK_H
+
+class FileLock {
+public:
+    class Lock {
+    public:
+        Lock() = delete;
+        Lock(const Lock &) = delete;
+        Lock &operator=(const Lock &) = delete;
+        Lock(FileLock *sem);
+        ~Lock();
+    private:
+        FileLock *ptr;
+        bool locked;
+    };
+
+    FileLock() = delete;
+    FileLock(const FileLock &) = delete;
+    FileLock &operator=(const FileLock &) = delete;
+    FileLock(const char* name);
+    ~FileLock();
+    bool Wait();
+    bool Unlock();
+
+private:
+    int fd_lock;
+};
+
+#endif //FILE_LOCK_H

--- a/Source/securityagent/ipclink.cpp
+++ b/Source/securityagent/ipclink.cpp
@@ -20,7 +20,8 @@
 #include "IPCSecurityToken.h"
 #include "securityagent.h"
 
-#include <mutex>
+// temporary solution for multiprocess
+#include "filelock.h"
 
 using namespace WPEFramework;
 
@@ -57,8 +58,8 @@ Core::ProxyPoolType<IPC::SecurityAgent::TokenData> _tokens(1);
  */
 int GetToken(unsigned short maxLength, unsigned short inLength, unsigned char buffer[])
 {
-    static std::mutex mtx;
-    std::unique_lock<std::mutex> lock(mtx);
+    FileLock fileLock("/tmp/.securityagent.lock");
+    FileLock::Lock lock(&fileLock);
 
     Core::IPCChannelClientType<Core::Void, false, true> channel(Core::NodeId(GetEndPoint().c_str()), 2048);
     int result = -1;


### PR DESCRIPTION
Reason for change: temporary solution for multiprocess
access to Core::IPCChannelClientType.
Test Procedure: Multiple processes should get token
in parallel.
Risks: Low
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>