### PR TITLE
Fix the CMakeLists.txt file of securityagent

### DIFF
--- a/Source/securityagent/CMakeLists.txt
+++ b/Source/securityagent/CMakeLists.txt
@@ -15,21 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-project(securityagent)
-
-cmake_minimum_required(VERSION 3.3)
-
-find_package(WPEFramework)
-
-project_version(1.0.0)
-
-set(TARGET ${PROJECT_NAME})
-
-message("Setup ${TARGET} v${PROJECT_VERSION}")
-
-#find_package(CompileSettingsDebug CONFIG REQUIRED)
-find_package(${NAMESPACE}Core REQUIRED)
-find_package(${NAMESPACE}COM REQUIRED)
+set(TARGET securityagent)
 
 # Construct a library object
 add_library(${TARGET} SHARED
@@ -48,10 +34,17 @@ target_link_libraries(${TARGET}
           ${NAMESPACE}Core::${NAMESPACE}Core
         )
 
+if(PROTOCOLS)
+target_link_libraries(${TARGET}
+        PUBLIC
+          ${NAMESPACE}Protocols::${NAMESPACE}Protocols
+        )
+else()
 target_link_libraries(${TARGET}
         PUBLIC
           ${NAMESPACE}COM::${NAMESPACE}COM
         )
+endif()
 
 # target_link_libraries(${TARGET}
 #        PRIVATE
@@ -89,3 +82,5 @@ InstallCMakeConfig(
 InstallPackageConfig(
         TARGETS ${TARGET} 
         DESCRIPTION "communications channel abstraction to get a SecurityToken over a process boundary." )
+
+add_subdirectory(sec_agent)

--- a/Source/securityagent/sec_agent/CMakeLists.txt
+++ b/Source/securityagent/sec_agent/CMakeLists.txt
@@ -1,0 +1,31 @@
+# If not stated otherwise in this file or this component's LICENSE file the
+# following copyright and licenses apply:
+#
+# Copyright 2020 RDK Management
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+add_executable(sec_agent main.cpp)
+
+target_include_directories(sec_agent 
+    PRIVATE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
+        $<INSTALL_INTERFACE:include/securityagent> 
+)
+
+target_link_libraries(sec_agent
+    PRIVATE
+        securityagent)
+
+install(TARGETS sec_agent 
+    DESTINATION bin)

--- a/Source/securityagent/sec_agent/main.cpp
+++ b/Source/securityagent/sec_agent/main.cpp
@@ -1,0 +1,81 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2020 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <ctype.h>
+#include <securityagent.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string>
+#include <cstring>
+
+#define Trace(fmt, ...)                                 \
+    do {                                                \
+        fprintf(stdout, "<< " fmt "\n", ##__VA_ARGS__); \
+        fflush(stdout);                                 \
+    } while (0)
+
+
+void ShowMenu()
+{
+    printf("Enter\n"
+           "\tG : Get Token.\n"
+           "\t? : Help\n"
+           "\tQ : Quit\n");
+}
+
+int main(int argc, char* argv[])
+{
+
+    ShowMenu();
+
+    int character;
+    do {
+        character = toupper(getc(stdin));
+
+        switch (character) {
+        case 'G': {
+             uint8_t buffer[2 * 1024];
+             std::string url("https://www.google.com");
+
+             std::string tokenAsString;
+             if (url.length() < sizeof(buffer)) {
+                ::memset (buffer, 0, sizeof(buffer));
+                ::memcpy (buffer, url.c_str(), url.length());
+                int length = GetToken(static_cast<uint16_t>(sizeof(buffer)), url.length(), buffer);
+                if (length > 0) {
+                   tokenAsString = std::string(reinterpret_cast<const char*>(buffer), length);
+                   printf("\nToken: %s\n",tokenAsString.c_str());
+                }
+                else
+                   printf("Error Getting token - %d\n",length);
+             }
+            break;
+        }
+        case '?': {
+            ShowMenu();
+            break;
+        }
+        default:
+            break;
+        }
+    } while (character != 'Q');
+
+    Trace("Done");
+
+    return 0;
+}


### PR DESCRIPTION
The last backport of securityagent RPC change from R3 to R2 broke the
cmake. Add also a sec_agent test utility.