### PR TITLE
Add a new version 2 of decrypt API to pass in Encryption Scheme and pattern

### DIFF
--- a/Source/ocdm/adapter/open_cdm_adapter.h
+++ b/Source/ocdm/adapter/open_cdm_adapter.h
@@ -46,6 +46,26 @@ extern "C" {
     EXTERNAL OpenCDMError opencdm_gstreamer_session_decrypt(struct OpenCDMSession* session, GstBuffer* buffer, GstBuffer* subSample, const uint32_t subSampleCount,
                                                    GstBuffer* IV, GstBuffer* keyID, uint32_t initWithLast15);
 
+/**
+ * \brief Performs decryption based on adapter implementation.
+ *
+ * This version 2 method accepts encrypted data and will typically decrypt it out-of-process (for security reasons). The actual data copying is performed
+ * using a memory-mapped file (for performance reasons). If the DRM system allows access to decrypted data (i.e. decrypting is not
+ * performed in a TEE), the decryption is performed in-place. EncryptionScheme and Pattern can be passed.
+ * \param session \ref OpenCDMSession instance.
+ * \param buffer Gstreamer buffer containing encrypted data and related meta data. If applicable, decrypted data will be stored here after this call returns.
+ * \param subSample Gstreamer buffer containing subsamples size which has been parsed from protection meta data.
+ * \param subSampleCount count of subsamples
+ * \param encScheme CENC Schemes as defined in EncryptionScheme enum
+ * \param pattern struct containing number of encrypted_blocks and clear_blocks
+ * \param IV Gstreamer buffer containing initial vector (IV) used during decryption.
+ * \param keyID Gstreamer buffer containing keyID to use for decryption
+ * \return Zero on success, non-zero on error.
+ */
+    
+    EXTERNAL OpenCDMError opencdm_gstreamer_session_decrypt_v2(struct OpenCDMSession* session, GstBuffer* buffer, GstBuffer* subSampleBuffer, const uint32_t subSampleCount,
+                                               const EncryptionScheme encScheme, const EncryptionPattern pattern,
+                                               GstBuffer* IV, GstBuffer* keyID, uint32_t initWithLast15);
 #ifdef __cplusplus
 }
 #endif

--- a/Source/ocdm/open_cdm.cpp
+++ b/Source/ocdm/open_cdm.cpp
@@ -474,6 +474,8 @@ OpenCDMError opencdm_session_close(struct OpenCDMSession* session)
 OpenCDMError opencdm_session_decrypt(struct OpenCDMSession* session,
     uint8_t encrypted[],
     const uint32_t encryptedLength,
+    const EncryptionScheme encScheme,
+    const EncryptionPattern pattern,
     const uint8_t* IV, const uint16_t IVLength,
     const uint8_t* keyId, const uint16_t keyIdLength,
     uint32_t initWithLast15 /* = 0 */)
@@ -482,7 +484,7 @@ OpenCDMError opencdm_session_decrypt(struct OpenCDMSession* session,
 
     if (session != nullptr) {
         result = encryptedLength > 0 ? static_cast<OpenCDMError>(session->Decrypt(
-            encrypted, encryptedLength, IV, IVLength, keyId, keyIdLength, initWithLast15)) : ERROR_NONE;
+            encrypted, encryptedLength, encScheme, pattern, IV, IVLength, keyId, keyIdLength, initWithLast15)) : ERROR_NONE;
     }
 
     return (result);

--- a/Source/ocdm/open_cdm.h
+++ b/Source/ocdm/open_cdm.h
@@ -109,6 +109,22 @@ typedef enum {
     PersistentLicense
 } LicenseType;
 
+// ISO/IEC 23001-7 defines two Common Encryption Schemes with Full Sample and Subsample modes
+typedef enum {
+    Clear = 0,
+    AesCtr_Cenc,    // AES-CTR mode and Sub-Sample encryption
+    AesCbc_Cbc1,    // AES-CBC mode and Sub-Sample encryption
+    AesCtr_Cens,    // AES-CTR mode and Sub-Sample + patterned encryption
+    AesCbc_Cbcs     // AES-CBC mode and Sub-Sample + patterned encryption + Constant IV
+} EncryptionScheme;
+
+//CENC3.0 pattern is a number of encrypted blocks followed a number of clear blocks after which the pattern repeats.
+typedef struct {
+    uint32_t encrypted_blocks;
+    uint32_t clear_blocks;
+} EncryptionPattern;
+
+
 /**
  * Key status.
  */
@@ -488,6 +504,8 @@ EXTERNAL OpenCDMError opencdm_session_close(struct OpenCDMSession* session);
  * \param encrypted Buffer containing encrypted data. If applicable, decrypted
  * data will be stored here after this call returns.
  * \param encryptedLength Length of encrypted data buffer (in bytes).
+ * \param encScheme CENC Schemes as defined in EncryptionScheme enum
+ * \param pattern Encryption pattern containing number of Encrypted and Clear blocks.
  * \param IV Initial vector (IV) used during decryption. Can be NULL, in that
  * case and IV of all zeroes is assumed.
  * \param IVLength Length of IV buffer (in bytes).
@@ -501,6 +519,8 @@ EXTERNAL OpenCDMError opencdm_session_close(struct OpenCDMSession* session);
 EXTERNAL OpenCDMError opencdm_session_decrypt(struct OpenCDMSession* session,
     uint8_t encrypted[],
     const uint32_t encryptedLength,
+    const EncryptionScheme encScheme,
+    const EncryptionPattern pattern, 
     const uint8_t* IV, uint16_t IVLength,
     const uint8_t* keyId, const uint16_t keyIdLength,
     uint32_t initWithLast15 = 0);
@@ -508,6 +528,8 @@ EXTERNAL OpenCDMError opencdm_session_decrypt(struct OpenCDMSession* session,
 EXTERNAL OpenCDMError opencdm_session_decrypt(struct OpenCDMSession* session,
     uint8_t encrypted[],
     const uint32_t encryptedLength,
+    const EncryptionScheme encScheme,
+    const EncryptionPattern pattern,
     const uint8_t* IV, uint16_t IVLength,
     const uint8_t* keyId, const uint16_t keyIdLength,
     uint32_t initWithLast15);

--- a/Source/ocdm/open_cdm_impl.h
+++ b/Source/ocdm/open_cdm_impl.h
@@ -401,6 +401,8 @@ private:
 
     public:
         uint32_t Decrypt(uint8_t* encryptedData, uint32_t encryptedDataLength,
+            const EncryptionScheme encScheme,
+            const EncryptionPattern& pattern,
             const uint8_t* ivData, uint16_t ivDataLength,
             const uint8_t* keyId, uint16_t keyIdLength,
             uint32_t initWithLast15 /* = 0 */)
@@ -422,8 +424,9 @@ private:
             if (RequestProduce(Core::infinite) == Core::ERROR_NONE) {
 
                 SetIV(static_cast<uint8_t>(ivDataLength), ivData);
-                SetSubSampleData(0, nullptr);
                 KeyId(static_cast<uint8_t>(keyIdLength), keyId);
+                SetEncScheme(static_cast<uint8_t>(encScheme));
+                SetEncPattern(pattern.encrypted_blocks,pattern.clear_blocks);
                 InitWithLast15(initWithLast15);
                 Write(encryptedDataLength, encryptedData);
 
@@ -604,6 +607,8 @@ public:
         _session->Update(pbResponse, cbResponse);
     }
     uint32_t Decrypt(uint8_t* encryptedData, const uint32_t encryptedDataLength,
+        const EncryptionScheme encScheme,
+        const EncryptionPattern& pattern,
         const uint8_t* ivData, uint16_t ivDataLength,
         const uint8_t* keyId, const uint16_t keyIdLength,
         uint32_t initWithLast15)
@@ -619,8 +624,10 @@ public:
         DataExchange* decryptSession = _decryptSession;
 
         if (decryptSession != nullptr) {
-            result = decryptSession->Decrypt(encryptedData, encryptedDataLength, ivData,
-                ivDataLength, keyId, keyIdLength,
+            result = decryptSession->Decrypt(encryptedData, encryptedDataLength, 
+                encScheme,pattern,
+                ivData,ivDataLength,
+                keyId, keyIdLength,
                 initWithLast15);
             if(result)
             {


### PR DESCRIPTION


The old decrypt API will try to fetch the pattern and scheme from Protection
metadata and call v2.