### PR TITLE
Check all available sessions for the given key and return any usable session

### DIFF
--- a/Source/ocdm/open_cdm.cpp
+++ b/Source/ocdm/open_cdm.cpp
@@ -504,13 +504,11 @@ bool OpenCDMAccessor::WaitForKey(const uint8_t keyLength, const uint8_t keyId[],
 
             for  (; session != _sessionKeys.end(); ++session) {
                 if (!system || session->second->BelongsTo(system) == true) {
-                    if (session->second->HasKeyId(keyLength, keyId) == true)
+                    if(session->second->Status(keyLength, keyId) == status) {
+                        result = true;
                         break;
+                    }
                 }
-            }
-
-            if (session != _sessionKeys.end()) {
-                result = (session->second->Status(keyLength, keyId) == status);
             }
 
             if (result == false) {


### PR DESCRIPTION
Step 3.4.3.1 and 3.4.3.3 of https://w3c.github.io/encrypted-media/#attempt-to-decrypt

There are issues observed in Amazon app when user enters into an asset details page and comes out of it quickly. This causes app to generate request but before the request is completed user leaves the asset forcing the app to close. This close doesn't succeed as the Session is not 'callable' yet. This leaves the session open and this remains in the WebKit & OpenCDMAccessor. When the same asset is played again, the current implementation (OpenCDMAccessor::WaitForKey) picks a random session for the given key and waits indefinitely for its status to be updated.

The patch tries to look at all the sessions which has the given key and returns the first one that is usable.