### PR TITLE
[ProvisionProxy] Define MODULE_NAME in archive

### DIFF
--- a/Source/provisionproxy/ipclink.cpp
+++ b/Source/provisionproxy/ipclink.cpp
@@ -29,6 +29,7 @@
 #include <provision/DRMInfo.h>
 
 #include "IPCProvision.h"
+MODULE_NAME_ARCHIVE_DECLARATION
 
 using namespace WPEFramework;
 


### PR DESCRIPTION
Use different declaration macro because ProvisionProxy is built as an archive. See also: https://github.com/rdkcentral/Thunder/pull/715