### PR TITLE
Allow error reporting for Decrypt/Encrypt methods

### DIFF
--- a/Source/cryptography/Cryptography.cpp
+++ b/Source/cryptography/Cryptography.cpp
@@ -167,14 +167,14 @@ namespace Implementation {
             }
 
         public:
-            uint32_t Encrypt(const uint8_t ivLength, const uint8_t iv[],
+            int32_t Encrypt(const uint8_t ivLength, const uint8_t iv[],
                             const uint32_t inputLength, const uint8_t input[],
                             const uint32_t maxOutputLength, uint8_t output[]) const override
             {
                 return (cipher_encrypt(_implementation, ivLength, iv, inputLength, input, maxOutputLength, output));
             }
 
-            uint32_t Decrypt(const uint8_t ivLength, const uint8_t iv[],
+            int32_t Decrypt(const uint8_t ivLength, const uint8_t iv[],
                             const uint32_t inputLength, const uint8_t input[],
                             const uint32_t maxOutputLength, uint8_t output[]) const override
             {

--- a/Source/cryptography/ICryptography.h
+++ b/Source/cryptography/ICryptography.h
@@ -76,12 +76,12 @@ namespace Cryptography {
         virtual ~ICipher() { }
 
         /* Encrypt data */
-        virtual uint32_t Encrypt(const uint8_t ivLength, const uint8_t iv[] /* @length:ivLength */,
+        virtual int32_t Encrypt(const uint8_t ivLength, const uint8_t iv[] /* @length:ivLength */,
                                  const uint32_t inputLength, const uint8_t input[] /* @length:inputLength */,
                                  const uint32_t maxOutputLength, uint8_t output[] /* @out @maxlength:maxOutputLength */) const = 0;
 
         /* Decrypt data */
-        virtual uint32_t Decrypt(const uint8_t ivLength, const uint8_t iv[] /* @length:ivLength */,
+        virtual int32_t Decrypt(const uint8_t ivLength, const uint8_t iv[] /* @length:ivLength */,
                                  const uint32_t inputLength, const uint8_t input[] /* @length:inputLength */,
                                  const uint32_t maxOutputLength, uint8_t output[] /* @out @maxlength:maxOutputLength */) const = 0;
     };

--- a/Source/cryptography/implementation/OpenSSL/Cipher.cpp
+++ b/Source/cryptography/implementation/OpenSSL/Cipher.cpp
@@ -34,11 +34,11 @@
 
 
 struct CipherImplementation {
-    virtual uint32_t Encrypt(const uint8_t ivLength, const uint8_t iv[],
+    virtual int32_t Encrypt(const uint8_t ivLength, const uint8_t iv[],
                              const uint32_t inputLength, const uint8_t input[],
                              const uint32_t maxOutputLength, uint8_t output[]) const = 0;
 
-    virtual uint32_t Decrypt(const uint8_t ivLength, const uint8_t iv[],
+    virtual int32_t Decrypt(const uint8_t ivLength, const uint8_t iv[],
                              const uint32_t inputLength, const uint8_t input[],
                              const uint32_t maxOutputLength, uint8_t output[]) const = 0;
 
@@ -79,14 +79,14 @@ public:
         }
     }
 
-    uint32_t Encrypt(const uint8_t ivLength, const uint8_t iv[],
+    int32_t Encrypt(const uint8_t ivLength, const uint8_t iv[],
                      const uint32_t inputLength, const uint8_t input[],
                      const uint32_t maxOutputLength, uint8_t output[]) const override
     {
         return (Operation(true, ivLength, iv, inputLength, input, maxOutputLength, output));
     }
 
-    uint32_t Decrypt(const uint8_t ivLength, const uint8_t iv[],
+    int32_t Decrypt(const uint8_t ivLength, const uint8_t iv[],
                      const uint32_t inputLength, const uint8_t input[],
                      const uint32_t maxOutputLength, uint8_t output[]) const override
     {
@@ -94,12 +94,12 @@ public:
     }
 
 private:
-    uint32_t Operation(bool encrypt,
+    int32_t Operation(bool encrypt,
                        const uint8_t ivLength, const uint8_t iv[],
                        const uint32_t inputLength, const uint8_t input[],
                        const uint32_t maxOutputLength, uint8_t output[]) const
     {
-        uint32_t result = 0;
+        int32_t result = 0;
 
         ASSERT(iv != nullptr);
         ASSERT(ivLength != 0);
@@ -245,14 +245,14 @@ void cipher_destroy(struct CipherImplementation* cipher)
     delete cipher;
 }
 
-uint32_t cipher_encrypt(const struct CipherImplementation* cipher, const uint8_t iv_length, const uint8_t iv[],
+int32_t cipher_encrypt(const struct CipherImplementation* cipher, const uint8_t iv_length, const uint8_t iv[],
                         const uint32_t input_length, const uint8_t input[], const uint32_t max_output_length, uint8_t output[])
 {
     ASSERT(cipher != nullptr);
     return (cipher->Encrypt(iv_length, iv, input_length, input, max_output_length, output));
 }
 
-uint32_t cipher_decrypt(const struct CipherImplementation* cipher, const uint8_t iv_length, const uint8_t iv[],
+int32_t cipher_decrypt(const struct CipherImplementation* cipher, const uint8_t iv_length, const uint8_t iv[],
                         const uint32_t input_length, const uint8_t input[], const uint32_t max_output_length, uint8_t output[])
 {
     ASSERT(cipher != nullptr);

--- a/Source/cryptography/implementation/SecApi/Cipher.cpp
+++ b/Source/cryptography/implementation/SecApi/Cipher.cpp
@@ -66,7 +66,7 @@ namespace Implementation {
      * @return Length of the bytesWritten as encrypted blob 
      *
      *********************************************************************/
-    uint32_t Cipher::Encrypt(const uint8_t ivLength, const uint8_t iv[], const uint32_t inputLength,
+    int32_t Cipher::Encrypt(const uint8_t ivLength, const uint8_t iv[], const uint32_t inputLength,
         const uint8_t input[], const uint32_t maxOutputLength, uint8_t output[]) const
     {
         return (Operation(true, ivLength, iv, inputLength, input, maxOutputLength, output));
@@ -87,7 +87,7 @@ namespace Implementation {
      * @return Length of the bytesWritten as decrypted blob/data
      *
      *********************************************************************/
-    uint32_t Cipher::Decrypt(const uint8_t ivLength, const uint8_t iv[], const uint32_t inputLength,
+    int32_t Cipher::Decrypt(const uint8_t ivLength, const uint8_t iv[], const uint32_t inputLength,
         const uint8_t input[], const uint32_t maxOutputLength, uint8_t output[]) const
     {
         return (Operation(false, ivLength, iv, inputLength, input, maxOutputLength, output));
@@ -109,7 +109,7 @@ namespace Implementation {
      * @return Length of the bytesWritten as encrypted/decrypted blob/data
      *
      *********************************************************************/
-    uint32_t Cipher::Operation(bool encrypt, const uint8_t ivLength, const uint8_t iv[], const uint32_t inputLength,
+    int32_t Cipher::Operation(bool encrypt, const uint8_t ivLength, const uint8_t iv[], const uint32_t inputLength,
         const uint8_t input[], const uint32_t maxOutputLength, uint8_t output[]) const
     {
         SEC_SIZE OutputLength = 0;
@@ -274,14 +274,14 @@ extern "C" {
         delete cipher;
     }
 
-    uint32_t cipher_encrypt(const struct CipherImplementation* cipher, const uint8_t iv_length, const uint8_t iv[],
+    int32_t cipher_encrypt(const struct CipherImplementation* cipher, const uint8_t iv_length, const uint8_t iv[],
         const uint32_t input_length, const uint8_t input[], const uint32_t max_output_length, uint8_t output[])
     {
         ASSERT(cipher != nullptr);
         return (cipher->Encrypt(iv_length, iv, input_length, input, max_output_length, output));
     }
 
-    uint32_t cipher_decrypt(const struct CipherImplementation* cipher, const uint8_t iv_length, const uint8_t iv[],
+    int32_t cipher_decrypt(const struct CipherImplementation* cipher, const uint8_t iv_length, const uint8_t iv[],
         const uint32_t input_length, const uint8_t input[], const uint32_t max_output_length, uint8_t output[])
     {
         ASSERT(cipher != nullptr);

--- a/Source/cryptography/implementation/SecApi/Cipher.h
+++ b/Source/cryptography/implementation/SecApi/Cipher.h
@@ -30,10 +30,10 @@
 
 
 struct CipherImplementation {
-    virtual uint32_t Encrypt(const uint8_t ivLength, const uint8_t iv[], const uint32_t inputLength,
+    virtual int32_t Encrypt(const uint8_t ivLength, const uint8_t iv[], const uint32_t inputLength,
         const uint8_t input[], const uint32_t maxOutputLength, uint8_t output[]) const = 0;
 
-    virtual uint32_t Decrypt(const uint8_t ivLength, const uint8_t iv[], const uint32_t inputLength,
+    virtual int32_t Decrypt(const uint8_t ivLength, const uint8_t iv[], const uint32_t inputLength,
         const uint8_t input[], const uint32_t maxOutputLength, uint8_t output[]) const = 0;
 
     virtual ~CipherImplementation() { }
@@ -54,14 +54,14 @@ namespace Implementation {
 
     public:
 
-        uint32_t Operation(bool encrypt, const uint8_t ivLength, const uint8_t iv[], const uint32_t inputLength,
+        int32_t Operation(bool encrypt, const uint8_t ivLength, const uint8_t iv[], const uint32_t inputLength,
             const uint8_t input[], const uint32_t maxOutputLength, uint8_t output[]) const;
 
         const Sec_CipherAlgorithm AESCipher(const aes_mode mode);
-        uint32_t Encrypt(const uint8_t ivLength, const uint8_t iv[], const uint32_t inputLength,
+        int32_t Encrypt(const uint8_t ivLength, const uint8_t iv[], const uint32_t inputLength,
             const uint8_t input[], const uint32_t maxOutputLength, uint8_t output[]) const override;
 
-        uint32_t Decrypt(const uint8_t ivLength, const uint8_t iv[], const uint32_t inputLength,
+        int32_t Decrypt(const uint8_t ivLength, const uint8_t iv[], const uint32_t inputLength,
             const uint8_t input[], const uint32_t maxOutputLength, uint8_t output[]) const override;
 
     private:
@@ -90,13 +90,13 @@ namespace Implementation {
     public:
 
         const Sec_CipherAlgorithm AESCipher(const aes_mode mode);
-        uint32_t Encrypt(const uint8_t ivLength, const uint8_t iv[], const uint32_t inputLength,
+        int32_t Encrypt(const uint8_t ivLength, const uint8_t iv[], const uint32_t inputLength,
             const uint8_t input[], const uint32_t maxOutputLength, uint8_t output[]) const override;
 
-        uint32_t Decrypt(const uint8_t ivLength, const uint8_t iv[], const uint32_t inputLength,
+        int32_t Decrypt(const uint8_t ivLength, const uint8_t iv[], const uint32_t inputLength,
             const uint8_t input[], const uint32_t maxOutputLength, uint8_t output[]) const override;
 
-        uint32_t Operation(bool encrypt, const uint8_t ivLength, const uint8_t iv[], const uint32_t inputLength,
+        int32_t Operation(bool encrypt, const uint8_t ivLength, const uint8_t iv[], const uint32_t inputLength,
             const uint8_t input[], const uint32_t maxOutputLength, uint8_t output[]) const;
     };
 

--- a/Source/cryptography/implementation/SecApi/CipherNetflix.cpp
+++ b/Source/cryptography/implementation/SecApi/CipherNetflix.cpp
@@ -62,7 +62,7 @@ namespace Implementation {
      * @return Length of the bytesWritten as encrypted blob
      *
      *********************************************************************/
-    uint32_t CipherNetflix::Encrypt(const uint8_t ivLength, const uint8_t iv[], const uint32_t inputLength,
+    int32_t CipherNetflix::Encrypt(const uint8_t ivLength, const uint8_t iv[], const uint32_t inputLength,
         const uint8_t input[], const uint32_t maxOutputLength, uint8_t output[]) const
     {
         return (Operation(true, ivLength, iv, inputLength, input, maxOutputLength, output));
@@ -83,7 +83,7 @@ namespace Implementation {
      * @return Length of the bytesWritten as decrypted blob/data
      *
      *********************************************************************/
-    uint32_t CipherNetflix::Decrypt(const uint8_t ivLength, const uint8_t iv[], const uint32_t inputLength,
+    int32_t CipherNetflix::Decrypt(const uint8_t ivLength, const uint8_t iv[], const uint32_t inputLength,
         const uint8_t input[], const uint32_t maxOutputLength, uint8_t output[]) const
     {
         return (Operation(false, ivLength, iv, inputLength, input, maxOutputLength, output));
@@ -105,12 +105,12 @@ namespace Implementation {
      * @return Length of the bytesWritten as encrypted/decrypted blob/data
      *
      *********************************************************************/
-    uint32_t CipherNetflix::Operation(bool encrypt, const uint8_t ivLength, const uint8_t iv[], const uint32_t inputLength,
+    int32_t CipherNetflix::Operation(bool encrypt, const uint8_t ivLength, const uint8_t iv[], const uint32_t inputLength,
         const uint8_t input[], const uint32_t maxOutputLength, uint8_t output[]) const
     {
 
         uint32_t keyHandle;
-        uint32_t retVal = -1;
+        int32_t retVal = -1;
         Sec_SocKeyHandle* pKey = NULL;
         SEC_SIZE            bytesWritten = 0;
         std::string outputbuf;

--- a/Source/cryptography/implementation/Thunder/Cipher.cpp
+++ b/Source/cryptography/implementation/Thunder/Cipher.cpp
@@ -29,7 +29,7 @@
 
 
 struct CryptImplementation {
-    virtual uint32_t Operation(const uint8_t ivLength, const uint8_t iv[],
+    virtual int32_t Operation(const uint8_t ivLength, const uint8_t iv[],
                                const uint32_t inputLength, const uint8_t input[],
                                const uint32_t maxOutputLength, uint8_t output[]) = 0;
 
@@ -45,14 +45,14 @@ namespace Operation {
 
     struct Encrypt {
         typedef WPEFramework::Crypto::AESEncryption Implementation;
-        static uint32_t Operation(Implementation& impl, const uint32_t length, const uint8_t input[], uint8_t output[]) {
+        static int32_t Operation(Implementation& impl, const uint32_t length, const uint8_t input[], uint8_t output[]) {
             return (impl.Encrypt(length, input, output));
         }
     };
 
     struct Decrypt {
         typedef WPEFramework::Crypto::AESDecryption Implementation;
-        static uint32_t Operation(Implementation& impl, const uint32_t length, const uint8_t input[], uint8_t output[]) {
+        static int32_t Operation(Implementation& impl, const uint32_t length, const uint8_t input[], uint8_t output[]) {
             return (impl.Decrypt(length, input, output));
         }
     };
@@ -78,11 +78,11 @@ public:
     ~AESCryptor() override = default;
 
 public:
-    uint32_t Operation(const uint8_t ivLength, const uint8_t iv[],
+    int32_t Operation(const uint8_t ivLength, const uint8_t iv[],
                        const uint32_t inputLength, const uint8_t input[],
                        const uint32_t maxOutputLength, uint8_t output[]) override
     {
-        uint32_t result = 0;
+        int32_t result = 0;
 
         ASSERT(iv != nullptr);
         ASSERT(input != nullptr);
@@ -222,7 +222,7 @@ void cipher_destroy(struct CryptImplementation* crypt)
     delete crypt;
 }
 
-uint32_t cipher_operation(struct CryptImplementation* crypt, const uint8_t iv_length, const uint8_t iv[],
+int32_t cipher_operation(struct CryptImplementation* crypt, const uint8_t iv_length, const uint8_t iv[],
                           const uint32_t input_length, const uint8_t input[], const uint32_t max_output_length, uint8_t output[])
 {
     ASSERT(crypt != nullptr);

--- a/Source/cryptography/implementation/cipher_implementation.h
+++ b/Source/cryptography/implementation/cipher_implementation.h
@@ -44,10 +44,10 @@ struct CipherImplementation* cipher_create_aes(const struct VaultImplementation*
 void cipher_destroy(struct CipherImplementation* cipher);
 
 
-uint32_t cipher_encrypt(const struct CipherImplementation* cipher, const uint8_t iv_length, const uint8_t iv[],
+int32_t cipher_encrypt(const struct CipherImplementation* cipher, const uint8_t iv_length, const uint8_t iv[],
                         const uint32_t input_length, const uint8_t input[], const uint32_t max_output_length, uint8_t output[]);
 
-uint32_t cipher_decrypt(const struct CipherImplementation* cipher, const uint8_t iv_length, const uint8_t iv[],
+int32_t cipher_decrypt(const struct CipherImplementation* cipher, const uint8_t iv_length, const uint8_t iv[],
                         const uint32_t input_length, const uint8_t input[], const uint32_t max_output_length, uint8_t output[]);
 
 #ifdef __cplusplus


### PR DESCRIPTION
This aligns with the R3 implementation and allows Decrypt/Encrypt
methods to return error through a negative values.