### PR TITLE
CompositorClient:RPI: set include path

### DIFF
--- a/Source/compositorclient/RPI/CMakeLists.txt
+++ b/Source/compositorclient/RPI/CMakeLists.txt
@@ -68,6 +68,7 @@ target_include_directories(${TARGET}
     PUBLIC
         $<INSTALL_INTERFACE:include/${NAMESPACE}>
     PRIVATE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/..>
         ${EGL_INCLUDE_DIRS})
 
 target_compile_definitions(${TARGET}

--- a/Source/virtualinput/CMakeLists.txt
+++ b/Source/virtualinput/CMakeLists.txt
@@ -58,9 +58,10 @@ set_target_properties(${TARGET} PROPERTIES
         )
 
 target_include_directories( ${TARGET}
-        PUBLIC
+        PRIVATE
           $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>
           $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/../>
+        PUBLIC
           $<INSTALL_INTERFACE:include/${NAMESPACE}>
           $<INSTALL_INTERFACE:include/${NAMESPACE}/virtualinput>
         )


### PR DESCRIPTION
Fix to solve the issue: /usr/lib/libcompositorclient.so.1: undefined symbol: VirtualInput with warning reporting enabled.