### PR TITLE
Close COM channel when last instance is deleted

### DIFF
--- a/Source/displayinfo/DisplayInfo.cpp
+++ b/Source/displayinfo/DisplayInfo.cpp
@@ -162,6 +162,11 @@ private:
                     std::list<DisplayInfo*>::erase(index);
                 }
                 delete const_cast<DisplayInfo*>(displayInfo);
+
+                if (_comChannel.IsValid()) {
+                    _comChannel.Release();
+                }
+
                 result = Core::ERROR_DESTRUCTION_SUCCEEDED;
             }
 


### PR DESCRIPTION
Upstreaming a patch from a customer environment:

Ensure that DisplayInfoAdministration::Delete() closes the COM channel when removing the last client instance in the list. The COM channel is opened by DisplayInfoAdministration::Instance() when creating the first client instance so, to keep the implementation symmetrical, it should conversely also close it when removing the last client instance. Without this, and because the DisplayInfoAdministration instance is static, the COM channel was only being closed by the DisplayInfoAdministration destructor, called in the context of the C library destructors invoking. However, at this point, closing if the COMchannel has undefined behavior because Thunder objects on which the channel closing depends have already been destructed. For instance, for closing the COM channel's socket, the Thunder's ResourceMonitor thread must be running, but at this point, it has already existed, so channel closing will never be able to complete.