### PR TITLE
Revert "cryptography: Remove LINK_WHAT_YOU_LIKE to avoid linking unused library + cryptography_test app compile again and compositorclient: remove as-needed flag to link graphics libs even there is no direct access"

### DIFF
--- a/Source/compositorclient/CMakeLists.txt
+++ b/Source/compositorclient/CMakeLists.txt
@@ -29,10 +29,6 @@ message("Setup ${TARGET} v${PROJECT_VERSION}")
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 
-# remove the -as-needed flag because it can lead to losing dependencies with platform graphics libs
-string(REPLACE "-Wl,--as-needed" "" CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS}")
-set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--no-as-needed")
-
 set(PLUGIN_COMPOSITOR_IMPLEMENTATION "None" CACHE STRING "Defines which implementation is used")
 
 find_package(CompileSettingsDebug CONFIG REQUIRED)

--- a/Source/cryptography/CMakeLists.txt
+++ b/Source/cryptography/CMakeLists.txt
@@ -29,6 +29,10 @@ message("Setup ${TARGET} v${PROJECT_VERSION}")
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
+# remove the -as-needed flag because it can lead to losing dependencies when we're mixing static and shared libs 
+string(REPLACE "-Wl,--as-needed" "" CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS}")
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--no-as-needed")
+
 option(INCLUDE_SOFTWARE_CRYPTOGRAPHY_LIBRARY "Include explicitly a software based cryptography library" OFF)
 
 find_package(ProxyStubGenerator REQUIRED)
@@ -36,7 +40,6 @@ find_package(ProxyStubGenerator REQUIRED)
 find_package(CompileSettingsDebug CONFIG REQUIRED)
 find_package(${NAMESPACE}Core REQUIRED)
 find_package(${NAMESPACE}COM REQUIRED)
-find_package(CompileSettingsDebug CONFIG REQUIRED)
 
 ProxyStubGenerator(
     NAMESPACE "WPEFramework::Cryptography" 
@@ -58,7 +61,6 @@ target_link_libraries(${TARGET}
     PRIVATE
         ${NAMESPACE}Core::${NAMESPACE}Core
         ${NAMESPACE}COM::${NAMESPACE}COM
-        CompileSettingsDebug::CompileSettingsDebug
         -Wl,--whole-archive implementation -Wl,--no-whole-archive
 )
 
@@ -82,6 +84,7 @@ set_target_properties(${TARGET} PROPERTIES
     CXX_STANDARD_REQUIRED YES
     FRAMEWORK FALSE
     PUBLIC_HEADER "${PUBLIC_HEADERS}"
+    LINK_WHAT_YOU_USE TRUE
     VERSION ${PROJECT_VERSION}
     SOVERSION ${PROJECT_VERSION_MAJOR}
 )
@@ -138,6 +141,7 @@ if(INCLUDE_SOFTWARE_CRYPTOGRAPHY_LIBRARY)
         CXX_STANDARD 11
         CXX_STANDARD_REQUIRED YES
         FRAMEWORK FALSE
+        LINK_WHAT_YOU_USE TRUE
         VERSION ${PROJECT_VERSION}
         SOVERSION ${PROJECT_VERSION_MAJOR}
     )

--- a/Source/cryptography/implementation/cipher_implementation.h
+++ b/Source/cryptography/implementation/cipher_implementation.h
@@ -39,14 +39,15 @@ typedef enum {
 struct CipherImplementation;
 
 
-EXTERNAL struct CipherImplementation* cipher_create_aes(const struct VaultImplementation* vault, const aes_mode mode, const uint32_t key_id);
+struct CipherImplementation* cipher_create_aes(const struct VaultImplementation* vault, const aes_mode mode, const uint32_t key_id);
 
-EXTERNAL void cipher_destroy(struct CipherImplementation* cipher);
+void cipher_destroy(struct CipherImplementation* cipher);
 
-EXTERNAL int32_t cipher_encrypt(const struct CipherImplementation* cipher, const uint8_t iv_length, const uint8_t iv[],
+
+int32_t cipher_encrypt(const struct CipherImplementation* cipher, const uint8_t iv_length, const uint8_t iv[],
                         const uint32_t input_length, const uint8_t input[], const uint32_t max_output_length, uint8_t output[]);
 
-EXTERNAL int32_t cipher_decrypt(const struct CipherImplementation* cipher, const uint8_t iv_length, const uint8_t iv[],
+int32_t cipher_decrypt(const struct CipherImplementation* cipher, const uint8_t iv_length, const uint8_t iv[],
                         const uint32_t input_length, const uint8_t input[], const uint32_t max_output_length, uint8_t output[]);
 
 #ifdef __cplusplus

--- a/Source/cryptography/implementation/diffiehellman_implementation.h
+++ b/Source/cryptography/implementation/diffiehellman_implementation.h
@@ -26,11 +26,11 @@
 extern "C" {
 #endif
 
-EXTERNAL uint32_t diffiehellman_generate(struct VaultImplementation* vault,
+uint32_t diffiehellman_generate(struct VaultImplementation* vault,
                                 const uint8_t generator, const uint16_t modulusSize, const uint8_t modulus[],
                                 uint32_t* private_key_id, uint32_t* public_key_id);
 
-EXTERNAL uint32_t diffiehellman_derive(struct VaultImplementation* vault,
+uint32_t diffiehellman_derive(struct VaultImplementation* vault,
                               const uint32_t private_key_id, const uint32_t peer_public_key_id, uint32_t* secret_id);
 
 #ifdef __cplusplus

--- a/Source/cryptography/implementation/hash_implementation.h
+++ b/Source/cryptography/implementation/hash_implementation.h
@@ -37,15 +37,16 @@ typedef enum {
 struct HashImplementation;
 
 
-EXTERNAL struct HashImplementation* hash_create(const hash_type type);
+struct HashImplementation* hash_create(const hash_type type);
 
-EXTERNAL struct HashImplementation* hash_create_hmac(const struct VaultImplementation* vault, const hash_type type, const uint32_t secret_id);
+struct HashImplementation* hash_create_hmac(const struct VaultImplementation* vault, const hash_type type, const uint32_t secret_id);
 
-EXTERNAL void hash_destroy(struct HashImplementation* signing);
+void hash_destroy(struct HashImplementation* signing);
 
-EXTERNAL uint32_t hash_ingest(struct HashImplementation* signing, const uint32_t length, const uint8_t data[]);
 
-EXTERNAL uint8_t hash_calculate(struct HashImplementation* signing, const uint8_t max_length, uint8_t data[]);
+uint32_t hash_ingest(struct HashImplementation* signing, const uint32_t length, const uint8_t data[]);
+
+uint8_t hash_calculate(struct HashImplementation* signing, const uint8_t max_length, uint8_t data[]);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/Source/cryptography/implementation/netflix_security_implementation.h
+++ b/Source/cryptography/implementation/netflix_security_implementation.h
@@ -27,13 +27,13 @@ extern "C" {
 
 /* Note: These calls adhere to the CRYPTOGRAPHY_VAULT_NETFLIX vault only. */
 
-EXTERNAL uint16_t netflix_security_esn(const uint16_t max_length, uint8_t data[]);
+uint16_t netflix_security_esn(const uint16_t max_length, uint8_t data[]);
 
-EXTERNAL uint32_t netflix_security_encryption_key(void);
+uint32_t netflix_security_encryption_key(void);
 
-EXTERNAL uint32_t netflix_security_hmac_key(void);
+uint32_t netflix_security_hmac_key(void);
 
-EXTERNAL uint32_t netflix_security_wrapping_key(void);
+uint32_t netflix_security_wrapping_key(void);
 
 /* Derive encryption keys based on an authenticated Diffie-Hellman procedure :
         1) secret = dh_shared_secret(private_key, peer_public_key)
@@ -42,8 +42,8 @@ EXTERNAL uint32_t netflix_security_wrapping_key(void);
         4) hmacKey = vector[16..47]                                      ; HMAC-256
         5) wrappingKey = HMAC-256(809f82a7addf548d3ea9dd067ff9bb91,
                                   HMAC-256(vector, 027617984f6227539a630b897c017d69))[0..15]  ; AES-128 */
-EXTERNAL uint32_t netflix_security_derive_keys(const uint32_t private_dh_key_id, const uint32_t peer_public_dh_key_id,
-    const uint32_t derivation_key_id, uint32_t* encryption_key_id, uint32_t* hmac_key_id, uint32_t* wrapping_key_id);
+uint32_t netflix_security_derive_keys(const uint32_t private_dh_key_id, const uint32_t peer_public_dh_key_id, const uint32_t derivation_key_id,
+                                      uint32_t* encryption_key_id, uint32_t* hmac_key_id, uint32_t* wrapping_key_id);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/Source/cryptography/implementation/persistent_implementation.h
+++ b/Source/cryptography/implementation/persistent_implementation.h
@@ -36,13 +36,14 @@ typedef enum {
         HMAC256
 }key_type;
 
-EXTERNAL uint32_t persistent_key_exists( struct VaultImplementation* vault ,const char locator[],bool* result);
+uint32_t persistent_key_exists( struct VaultImplementation* vault ,const char locator[],bool* result);
 
-EXTERNAL uint32_t persistent_key_load(struct VaultImplementation* vault,const char locator[],uint32_t*  id);
+uint32_t persistent_key_load(struct VaultImplementation* vault,const char locator[],uint32_t*  id);
 
-EXTERNAL uint32_t persistent_key_create( struct VaultImplementation* vault,const char locator[],const key_type keyType,uint32_t* id);
+uint32_t persistent_key_create( struct VaultImplementation* vault,const char locator[],const key_type keyType,uint32_t* id);
 
-EXTERNAL uint32_t persistent_flush(struct VaultImplementation* vault);
+uint32_t persistent_flush(struct VaultImplementation* vault);
+
 
 #ifdef __cplusplus
 } // extern "C"

--- a/Source/cryptography/implementation/vault_implementation.h
+++ b/Source/cryptography/implementation/vault_implementation.h
@@ -23,18 +23,6 @@
 #include <stdbool.h>
 #include "cryptography_vault_ids.h"
 
-#undef EXTERNAL
-#if defined(WIN32) || defined(_WINDOWS) || defined (__CYGWIN__) || defined(_WIN64)
-#ifdef DEVICEINFO_EXPORTS
-#define EXTERNAL __declspec(dllexport)
-#else
-#define EXTERNAL __declspec(dllimport)
-#pragma comment(lib, "crypto.lib")
-#endif
-#else
-#define EXTERNAL __attribute__((visibility("default")))
-#endif
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -42,19 +30,19 @@ extern "C" {
 
 struct VaultImplementation;
 
-EXTERNAL struct VaultImplementation* vault_instance(const enum cryptographyvault id);
+struct VaultImplementation* vault_instance(const enum cryptographyvault id);
 
-EXTERNAL uint16_t vault_size(const struct VaultImplementation* vault, const uint32_t id);
+uint16_t vault_size(const struct VaultImplementation* vault, const uint32_t id);
 
-EXTERNAL uint32_t vault_import(struct VaultImplementation* vault, const uint16_t length, const uint8_t blob[]);
+uint32_t vault_import(struct VaultImplementation* vault, const uint16_t length, const uint8_t blob[]);
 
-EXTERNAL uint16_t vault_export(const struct VaultImplementation* vault, const uint32_t id, const uint16_t max_length, uint8_t blob[]);
+uint16_t vault_export(const struct VaultImplementation* vault, const uint32_t id, const uint16_t max_length, uint8_t blob[]);
 
-EXTERNAL uint32_t vault_set(struct VaultImplementation* vault, const uint16_t length, const uint8_t blob[]);
+uint32_t vault_set(struct VaultImplementation* vault, const uint16_t length, const uint8_t blob[]);
 
-EXTERNAL uint16_t vault_get(const struct VaultImplementation* vault, const uint32_t id, const uint16_t max_length, uint8_t blob[]);
+uint16_t vault_get(const struct VaultImplementation* vault, const uint32_t id, const uint16_t max_length, uint8_t blob[]);
 
-EXTERNAL bool vault_delete(struct VaultImplementation* vault, const uint32_t id);
+bool vault_delete(struct VaultImplementation* vault, const uint32_t id);
 
 
 #ifdef __cplusplus

--- a/Source/cryptography/tests/CMakeLists.txt
+++ b/Source/cryptography/tests/CMakeLists.txt
@@ -14,7 +14,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-option(BUILD_CRYPTOGRAPHY_TESTS "Build cryptography test" ON)
+option(BUILD_CRYPTOGRAPHY_TESTS "Build cryptography test" OFF)
 option(BUILD_CRYPTOGRAPHY_RPC_TESTS "Build cryptography rpc test" OFF)
 
 if (BUILD_CRYPTOGRAPHY_TESTS)

--- a/Source/cryptography/tests/cryptography_test/CMakeLists.txt
+++ b/Source/cryptography/tests/cryptography_test/CMakeLists.txt
@@ -17,7 +17,7 @@
 
 option(BUILD_NETFLIX_VAULT_GENERATOR "Build Netflix Vault generator" OFF)
 
-find_package(${NAMESPACE}Plugins REQUIRED)
+
 include_directories(${CMAKE_CURRENT_LIST_DIR}/../../../../Source)
 
 set(CMAKE_CXX_STANDARD 11)
@@ -35,17 +35,12 @@ include_directories(${CMAKE_CURRENT_LIST_DIR}/../../../cryptography)
 include_directories(${CMAKE_CURRENT_LIST_DIR}/../../../cryptography/implementation)
 include_directories($<INSTALL_INTERFACE:include/${NAMESPACE}>)
 
-set_target_properties(cgimptests PROPERTIES
-        CXX_STANDARD 11
-        CXX_STANDARD_REQUIRED YES
-    )
-
 target_link_libraries(cgimptests
         PRIVATE
         ${NAMESPACE}Cryptography
-        ${NAMESPACE}Plugins::${NAMESPACE}Plugins
         ssl
         crypto
+        -Wl,--warn-unresolved-symbols
     )
 
 
@@ -69,16 +64,10 @@ set_target_properties(cgfacetests PROPERTIES
 target_link_libraries(cgfacetests
         PRIVATE
         ${NAMESPACE}Cryptography
-        ${NAMESPACE}Plugins::${NAMESPACE}Plugins
         ssl
         crypto
+        -Wl,--warn-unresolved-symbols
     )
-
-target_include_directories(cgfacetests
-    PRIVATE
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/../../..>
-)
-
 
 add_executable(cgnfsecuritytests
         NetflixSecurityTests.cpp
@@ -98,9 +87,9 @@ set_target_properties(cgnfsecuritytests PROPERTIES
 target_link_libraries(cgnfsecuritytests
         PRIVATE
         ${NAMESPACE}Cryptography
-        ${NAMESPACE}Plugins::${NAMESPACE}Plugins
         ssl
         crypto
+        -Wl,--warn-unresolved-symbols
     )
 
 install(TARGETS cgimptests DESTINATION bin)


### PR DESCRIPTION
Reverts rdkcentral/ThunderClientLibraries#172