### PR TITLE
BCM72180-247: There is a common fix needed in ThunderClientLibraries

### DIFF
--- a/Source/cryptography/implementation/OpenSSL/Cipher.cpp
+++ b/Source/cryptography/implementation/OpenSSL/Cipher.cpp
@@ -133,8 +133,9 @@ private:
                         TRACE_L1(_T("EVP_CipherUpdate() failed"));
                     } else {
                         result = len;
+			len = 0;
                         // Note: EVP_CipherFinal_ex() can still write to the output buffer!
-                        if (EVP_CipherFinal_ex(_context, (output + len), &len) == 0) {
+                        if (EVP_CipherFinal_ex(_context, (output + result), &len) == 0) {
                             TRACE_L1(_T("EVP_CipherFinal_ex() failed"));
                             result = 0;
                         } else {

--- a/Source/cryptography/implementation/OpenSSL/Hash.cpp
+++ b/Source/cryptography/implementation/OpenSSL/Hash.cpp
@@ -80,7 +80,7 @@ namespace Operation {
             return (EVP_DigestUpdate(ctx, d, cnt));
         }
         static int Final(EVP_MD_CTX* ctx, unsigned char* sig, size_t* siglen) {
-            uint32_t siglen32 = (*siglen);
+            uint32_t siglen32 = 0
             int rv = EVP_DigestFinal(ctx, sig, &siglen32);
             (*siglen) = siglen32;
             return (rv);

--- a/Source/cryptography/implementation/OpenSSL/Vault.cpp
+++ b/Source/cryptography/implementation/OpenSSL/Vault.cpp
@@ -179,7 +179,8 @@ uint16_t Vault::Cipher(bool encrypt, const uint16_t inSize, const uint8_t input[
         EVP_CipherInit_ex(ctx, EVP_aes_128_ctr(), nullptr, reinterpret_cast<const unsigned char*>(_vaultKey.data()), iv, encrypt);
         EVP_CipherUpdate(ctx, outputBuffer, &outLen, inputBuffer, inputSize);
         totalLen += outLen;
-        EVP_EncryptFinal_ex(ctx, (outputBuffer + outLen), &outLen);
+	outLen = 0;
+	EVP_EncryptFinal_ex(ctx, (output + totalLen), &outLen);
         totalLen += outLen;
 
         EVP_CIPHER_CTX_cleanup(ctx);


### PR DESCRIPTION
Reason for change: fixes the crash observed in Cryptography test suite Test Procedure: Build and verify.
Risks: Low

Note : Change taken from accelerator device
Signed-off-by: Vijith T V <vijith.tv@ltts.com>