### PR TITLE
Fixing libdrm target name in compositorclient/RPI/CMakeLists.txt

### DIFF
--- a/Source/compositorclient/RPI/CMakeLists.txt
+++ b/Source/compositorclient/RPI/CMakeLists.txt
@@ -44,7 +44,7 @@ target_link_libraries(${PLUGIN_COMPOSITOR_IMPLEMENTATION}
 if(VC6)
     target_link_libraries(${PLUGIN_COMPOSITOR_IMPLEMENTATION}
         PUBLIC
-            LibDRM::LibDRM
+            libdrm::libdrm
     )
 endif()
 


### PR DESCRIPTION
Broken by target name change in [5aca10](https://github.com/rdkcentral/ThunderClientLibraries/commit/5aca10)