### PR TITLE
[Warnings] Adding pedantic warnings and treating all warnings as errors, fixing warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,10 +19,31 @@
 cmake_minimum_required(VERSION 3.3)
 project(ClientLibraries)
 
+find_package(WPEFramework)
+
 option(INSTALL_TESTS "Install the test applications" OFF)
 
 if (BUILD_REFERENCE)
     add_definitions (-DBUILD_REFERENCE=${BUILD_REFERENCE})
+endif()
+
+if(ENABLE_STRICT_COMPILER_SETTINGS)
+    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+        message(FATAL_ERROR "Compiling with Clang")
+        set(CMAKE_STRICT_COMPILER_SETTINGS "-Weverything -Wextra -Wpedantic -Werror")
+        set(CMAKE_STRICT_CXX_COMPILER_SETTINGS "${CMAKE_STRICT_COMPILER_SETTINGS} -Wnon-virtual-dtor")
+    elseif(${CMAKE_COMPILER_IS_GNUCXX})
+        message(STATUS "Compiling with GCC")
+        set(CMAKE_STRICT_COMPILER_SETTINGS "-Wall -Wextra -Wpedantic -Werror")
+        set(CMAKE_STRICT_CXX_COMPILER_SETTINGS "${CMAKE_STRICT_COMPILER_SETTINGS} -Wnon-virtual-dtor")
+    elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+        message(STATUS "Compiling with MS Visual Studio")
+        set(CMAKE_STRICT_COMPILER_SETTINGS "/W4")
+    else()
+        message(STATUS "Compiler ${CMAKE_CXX_COMPILER_ID}")
+    endif()
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CMAKE_STRICT_CXX_COMPILER_SETTINGS}")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${CMAKE_STRICT_COMPILER_SETTINGS}")
 endif()
 
 add_subdirectory(Source)

--- a/Source/cryptography/implementation/OpenSSL/DiffieHellman.cpp
+++ b/Source/cryptography/implementation/OpenSSL/DiffieHellman.cpp
@@ -198,7 +198,7 @@ private:
         uint16_t generatorSize;
         uint16_t privateKeySize;
         uint16_t publicKeySize;
-PUSH_WARNING(DISABLE_WARNING_NON_STANDARD_EXTENSION_USED)
+PUSH_WARNING(DISABLE_WARNING_NON_STANDARD_EXTENSION_USED, DISABLE_WARNING_PEDANTIC)
         uint8_t data[0];
 POP_WARNING()
 

--- a/Source/cryptography/implementation/OpenSSL/Hash.cpp
+++ b/Source/cryptography/implementation/OpenSSL/Hash.cpp
@@ -226,7 +226,7 @@ HashImplementation* hash_create(const hash_type type)
     }
 
     return (implementation);
-};
+}
 
 HashImplementation* hash_create_hmac(const VaultImplementation* vault, const hash_type type, const uint32_t secret_id)
 {

--- a/Source/cryptography/implementation/OpenSSL/Vault.cpp
+++ b/Source/cryptography/implementation/OpenSSL/Vault.cpp
@@ -88,7 +88,7 @@ namespace Netflix {
                     TRACE_L1(_T("Set label to default \"%s\""), label.c_str());
                 }
 
-PUSH_WARNING(DISABLE_WARNING_NON_STANDARD_EXTENSION_USED)
+PUSH_WARNING(DISABLE_WARNING_NON_STANDARD_EXTENSION_USED, DISABLE_WARNING_PEDANTIC)
                 struct NetflixData {
                     uint8_t salt[16];
                     uint8_t kpe[16];
@@ -152,7 +152,7 @@ POP_WARNING()
         WPEFramework::Core::File file(path);
 
         if (file.Open(true) == true) {
-PUSH_WARNING(DISABLE_WARNING_NON_STANDARD_EXTENSION_USED)
+PUSH_WARNING(DISABLE_WARNING_NON_STANDARD_EXTENSION_USED, DISABLE_WARNING_PEDANTIC)
             struct NetflixData {
                 uint8_t salt[16];
                 uint8_t kpe[16];

--- a/Source/ocdm/CMakeLists.txt
+++ b/Source/ocdm/CMakeLists.txt
@@ -105,7 +105,7 @@ target_link_libraries(${TARGET}
         )
 
 target_include_directories( ${TARGET}
-        PRIVATE
+        SYSTEM PRIVATE
         ${GSTREAMER_INCLUDES}
         ${GSTREAMER_BASE_INCLUDES}
         )


### PR DESCRIPTION
@pwielders do we want to disable pedantic warnings around the zero-sized array declaration like I did, or maybe it would be better to somehow change it?