### PR TITLE
[Actions] Managing dependencies to make the workflows callable from different repos

### DIFF
--- a/.github/workflows/Build ThunderClientLibraries on Linux.yml
+++ b/.github/workflows/Build ThunderClientLibraries on Linux.yml
@@ -5,11 +5,14 @@ on:
     # branches: ["master"]
   pull_request:
     branches: ["master"]
-  workflow_call:
 
 jobs:
+  Thunder:
+    uses: VeithMetro/Thunder/.github/workflows/Linux build template.yml@development/actions
+
   ThunderInterfaces:
-    uses: rdkcentral/ThunderInterfaces/.github/workflows/Build ThunderInterfaces on Linux.yml@master
+    needs: Thunder
+    uses: VeithMetro/ThunderInterfaces/.github/workflows/Linux build template.yml@development/actions
 
   ThunderClientLibraries:
     needs: ThunderInterfaces

--- a/.github/workflows/Build ThunderClientLibraries on Linux.yml
+++ b/.github/workflows/Build ThunderClientLibraries on Linux.yml
@@ -2,7 +2,7 @@ name: Build ThunderClientLibraries on Linux
 
 on:
   push:
-    branches: ["master"]
+    # branches: ["master"]
   pull_request:
     branches: ["master"]
   workflow_call:
@@ -13,88 +13,4 @@ jobs:
 
   ThunderClientLibraries:
     needs: ThunderInterfaces
-
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        build_type: [Debug, Release, MinSizeRel]
-
-    name: Build type - ${{matrix.build_type}}
-    steps:
-    - name: Install necessary packages
-      uses: nick-fields/retry@v2
-      with:
-        timeout_minutes: 10
-        max_attempts: 10
-        command: |
-          sudo gem install apt-spy2
-          sudo apt-spy2 fix --commit --launchpad --country=US
-          sudo apt-get update
-          sudo apt install python3-pip
-          pip install jsonref
-          sudo apt install build-essential cmake ninja-build libusb-1.0-0-dev zlib1g-dev libssl-dev
-
-    - name: Checkout Thunder
-      uses: actions/checkout@v3
-      with:
-        path: Thunder
-        repository: ${{github.repository_owner}}/Thunder
-
-    - name: Checkout ThunderInterfaces
-      uses: actions/checkout@v3
-      with:
-        path: ThunderInterfaces
-        repository: ${{github.repository_owner}}/ThunderInterfaces
-
-    - name: Download artifacts
-      uses: actions/download-artifact@v3
-      with:
-        name: ThunderInterfaces-${{matrix.build_type}}-artifact
-        path: ${{matrix.build_type}}
-
-    - name: Unpack files
-      run: |
-        tar -xvzf ${{matrix.build_type}}/${{matrix.build_type}}.tar.gz
-        rm ${{matrix.build_type}}/${{matrix.build_type}}.tar.gz
-
-    - name: Checkout ThunderClientLibraries
-      uses: actions/checkout@v3
-      with:
-        path: ThunderClientLibraries
-        repository: ${{github.repository_owner}}/ThunderClientLibraries
-
-    - name: Regex ThunderClientLibraries
-      if: contains(github.event.pull_request.body, '[Options:')
-      id: clientlibs
-      uses: AsasInnab/regex-action@v1
-      with:
-        regex_pattern: '(?<=\[Options:).*(?=\])'
-        regex_flags: 'gim'
-        search_string: ${{github.event.pull_request.body}}
-
-    - name: Build ThunderClientLibraries
-      run: |
-        cmake -G Ninja -S ThunderClientLibraries -B ${{matrix.build_type}}/build/ThunderClientLibraries \
-        -DCMAKE_CXX_FLAGS="-Wall -Wextra -Wpedantic -Werror" \
-        -DCMAKE_INSTALL_PREFIX="${{matrix.build_type}}/install/usr" \
-        -DCMAKE_MODULE_PATH="${PWD}/${{matrix.build_type}}/install/usr/include/WPEFramework/Modules" \
-        -DBLUETOOTHAUDIOSINK=ON \
-        -DDEVICEINFO=ON \
-        -DDISPLAYINFO=ON \
-        -DLOCALTRACER=ON \
-        -DSECURITYAGENT=ON \
-        -DPLAYERINFO=ON \
-        -DPROTOCOLS=ON \
-        -DVIRTUALINPUT=ON \
-        ${{steps.clientlibs.outputs.first_match}}
-        cmake --build ${{matrix.build_type}}/build/ThunderClientLibraries --target install
-
-    - name: Tar files
-      run: tar -czvf ${{matrix.build_type}}.tar.gz ${{matrix.build_type}}
-
-    - name: Upload
-      uses: actions/upload-artifact@v3
-      with:
-        name: ThunderClientLibraries-${{matrix.build_type}}-artifact
-        path: ${{matrix.build_type}}.tar.gz
+    uses: VeithMetro/ThunderClientLibraries/.github/workflows/Linux build template.yml@development/actions

--- a/.github/workflows/Build ThunderClientLibraries on Linux.yml
+++ b/.github/workflows/Build ThunderClientLibraries on Linux.yml
@@ -2,7 +2,7 @@ name: Build ThunderClientLibraries on Linux
 
 on:
   push:
-    # branches: ["master"]
+    branches: ["master"]
   pull_request:
     branches: ["master"]
 

--- a/.github/workflows/Linux build template.yml
+++ b/.github/workflows/Linux build template.yml
@@ -1,0 +1,92 @@
+name: Build ThunderClientLibraries on Linux
+
+on:
+  workflow_call:
+
+jobs:
+  ThunderClientLibraries:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        build_type: [Debug, Release, MinSizeRel]
+
+    name: Build type - ${{matrix.build_type}}
+    steps:
+    - name: Install necessary packages
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 10
+        max_attempts: 10
+        command: |
+          sudo gem install apt-spy2
+          sudo apt-spy2 fix --commit --launchpad --country=US
+          sudo apt-get update
+          sudo apt install python3-pip
+          pip install jsonref
+          sudo apt install build-essential cmake ninja-build libusb-1.0-0-dev zlib1g-dev libssl-dev
+
+    - name: Checkout Thunder
+      uses: actions/checkout@v3
+      with:
+        path: Thunder
+        repository: ${{github.repository_owner}}/Thunder
+
+    - name: Checkout ThunderInterfaces
+      uses: actions/checkout@v3
+      with:
+        path: ThunderInterfaces
+        repository: ${{github.repository_owner}}/ThunderInterfaces
+
+    - name: Download artifacts
+      uses: actions/download-artifact@v3
+      with:
+        name: ThunderInterfaces-${{matrix.build_type}}-artifact
+        path: ${{matrix.build_type}}
+
+    - name: Unpack files
+      run: |
+        tar -xvzf ${{matrix.build_type}}/${{matrix.build_type}}.tar.gz
+        rm ${{matrix.build_type}}/${{matrix.build_type}}.tar.gz
+
+    - name: Checkout ThunderClientLibraries
+      uses: actions/checkout@v3
+      with:
+        path: ThunderClientLibraries
+        repository: ${{github.repository_owner}}/ThunderClientLibraries
+
+    - name: Regex ThunderClientLibraries
+      if: contains(github.event.pull_request.body, '[Options:')
+      id: clientlibs
+      uses: AsasInnab/regex-action@v1
+      with:
+        regex_pattern: '(?<=\[Options:).*(?=\])'
+        regex_flags: 'gim'
+        search_string: ${{github.event.pull_request.body}}
+
+    - name: Build ThunderClientLibraries
+      run: |
+        cmake -G Ninja -S ThunderClientLibraries -B ${{matrix.build_type}}/build/ThunderClientLibraries \
+        -DCMAKE_CXX_FLAGS="-Wall -Wextra -Wpedantic -Werror" \
+        -DCMAKE_INSTALL_PREFIX="${{matrix.build_type}}/install/usr" \
+        -DCMAKE_MODULE_PATH="${PWD}/${{matrix.build_type}}/install/usr/include/WPEFramework/Modules" \
+        -DBLUETOOTHAUDIOSINK=ON \
+        -DDEVICEINFO=ON \
+        -DDISPLAYINFO=ON \
+        -DLOCALTRACER=ON \
+        -DSECURITYAGENT=ON \
+        -DPLAYERINFO=ON \
+        -DPROTOCOLS=ON \
+        -DVIRTUALINPUT=ON \
+        ${{steps.clientlibs.outputs.first_match}}
+        cmake --build ${{matrix.build_type}}/build/ThunderClientLibraries --target install
+
+    - name: Tar files
+      run: tar -czvf ${{matrix.build_type}}.tar.gz ${{matrix.build_type}}
+
+    - name: Upload
+      uses: actions/upload-artifact@v3
+      with:
+        name: ThunderClientLibraries-${{matrix.build_type}}-artifact
+        path: ${{matrix.build_type}}.tar.gz


### PR DESCRIPTION
Same as with the Thunder PR: https://github.com/rdkcentral/Thunder/pull/1496

This is an initial pull request - the new workflows have to be called from my branches for now (there is a dependency between the workflows), since we need to first merge new templates in each repo. Then, I'll make one more set of pull requests to redirect this new feature to master branches of our repos.

Required checks got updated to the new ones by Stephen.