### PR TITLE
[Actions] Using the already merged workflows instead of my forks

### DIFF
--- a/.github/workflows/Build ThunderClientLibraries on Linux.yml
+++ b/.github/workflows/Build ThunderClientLibraries on Linux.yml
@@ -2,18 +2,18 @@ name: Build ThunderClientLibraries on Linux
 
 on:
   push:
-    branches: ["master"]
+    # branches: ["master"]
   pull_request:
     branches: ["master"]
 
 jobs:
   Thunder:
-    uses: VeithMetro/Thunder/.github/workflows/Linux build template.yml@development/actions
+    uses: rdkcentral/Thunder/.github/workflows/Linux build template.yml@master
 
   ThunderInterfaces:
     needs: Thunder
-    uses: VeithMetro/ThunderInterfaces/.github/workflows/Linux build template.yml@development/actions
+    uses: rdkcentral/ThunderInterfaces/.github/workflows/Linux build template.yml@master
 
   ThunderClientLibraries:
     needs: ThunderInterfaces
-    uses: VeithMetro/ThunderClientLibraries/.github/workflows/Linux build template.yml@development/actions
+    uses: rdkcentral/ThunderClientLibraries/.github/workflows/Linux build template.yml@master

--- a/.github/workflows/Build ThunderClientLibraries on Linux.yml
+++ b/.github/workflows/Build ThunderClientLibraries on Linux.yml
@@ -2,7 +2,7 @@ name: Build ThunderClientLibraries on Linux
 
 on:
   push:
-    # branches: ["master"]
+    branches: ["master"]
   pull_request:
     branches: ["master"]
 


### PR DESCRIPTION
The last set of pull requests, now the new Actions will use workflows from our repos instead of my forks, which sadly couldn't have been done in one go.