### PR TITLE
[OCDM] Add functionality to construct Session private data.

### DIFF
--- a/Source/ocdm/CMakeLists.txt
+++ b/Source/ocdm/CMakeLists.txt
@@ -44,6 +44,7 @@ add_library(${TARGET} SHARED
         CapsParser.cpp
         open_cdm.cpp
         open_cdm_ext.cpp
+        open_cdm_impl.cpp
         )
 
 set(PUBLIC_HEADERS

--- a/Source/ocdm/adapter/gstreamer/open_cdm_adapter.cpp
+++ b/Source/ocdm/adapter/gstreamer/open_cdm_adapter.cpp
@@ -39,6 +39,19 @@ inline bool mappedBuffer(GstBuffer *buffer, bool writable, uint8_t **data, uint3
     return true;
 }
 
+uint32_t opencdm_construct_session_private(struct OpenCDMSession* session, void* &pvtData)
+{
+    pvtData = nullptr;
+    TRACE_L1("opencdm_construct_session_private: nothing to construct");
+    return ERROR_NONE;
+}
+
+uint32_t opencdm_destruct_session_private(struct OpenCDMSession* session, void* &pvtData)
+{
+    TRACE_L1("opencdm_destruct_session_private: nothing to destruct");
+    return ERROR_NONE;
+}
+
 OpenCDMError opencdm_gstreamer_session_decrypt(struct OpenCDMSession* session, GstBuffer* buffer, GstBuffer* subSampleBuffer, const uint32_t subSampleCount,
                                                GstBuffer* IV, GstBuffer* keyID, uint32_t initWithLast15)
 {

--- a/Source/ocdm/adapter/gstreamer/open_cdm_adapter.cpp
+++ b/Source/ocdm/adapter/gstreamer/open_cdm_adapter.cpp
@@ -39,19 +39,6 @@ inline bool mappedBuffer(GstBuffer *buffer, bool writable, uint8_t **data, uint3
     return true;
 }
 
-uint32_t opencdm_construct_session_private(struct OpenCDMSession* session, void* &pvtData)
-{
-    pvtData = nullptr;
-    TRACE_L1("opencdm_construct_session_private: nothing to construct");
-    return ERROR_NONE;
-}
-
-uint32_t opencdm_destruct_session_private(struct OpenCDMSession* session, void* &pvtData)
-{
-    TRACE_L1("opencdm_destruct_session_private: nothing to destruct");
-    return ERROR_NONE;
-}
-
 OpenCDMError opencdm_gstreamer_session_decrypt(struct OpenCDMSession* session, GstBuffer* buffer, GstBuffer* subSampleBuffer, const uint32_t subSampleCount,
                                                GstBuffer* IV, GstBuffer* keyID, uint32_t initWithLast15)
 {

--- a/Source/ocdm/adapter/open_cdm_adapter.h
+++ b/Source/ocdm/adapter/open_cdm_adapter.h
@@ -33,6 +33,31 @@ extern "C" {
 #endif
 
 /**
+ * \brief Creates private data required for decryption.
+ *
+ * This method allows for creation of private data that is associated with the session. The private data itself is
+ * opaque to OpenCDMSession.
+ *
+ * \param session \ref OpenCDMSession instance.
+ * \param pvtData Output parameter that will contain the Opaque private data created
+ *
+ * \return Zero on success, non-zero on error.
+ */
+EXTERNAL uint32_t opencdm_construct_session_private(struct OpenCDMSession* session, void* &pvtData);
+
+/**
+ * \brief Destroys private data associated with the Session.
+ *
+ * This method destroys the private data that is associated with the session.
+ *
+ * \param session \ref OpenCDMSession instance.
+ * \param pvtData Input parameter pointer to private data.
+ *
+ * \return Zero on success, non-zero on error.
+ */
+EXTERNAL uint32_t opencdm_destruct_session_private(struct OpenCDMSession* session, void* &pvtData);
+
+/**
  * \brief Performs decryption based on adapter implementation.
  *
  * This method accepts encrypted data and will typically decrypt it out-of-process (for security reasons). The actual data copying is performed

--- a/Source/ocdm/adapter/open_cdm_adapter.h
+++ b/Source/ocdm/adapter/open_cdm_adapter.h
@@ -36,7 +36,7 @@ extern "C" {
  * \brief Creates private data required for decryption.
  *
  * This method allows for creation of private data that is associated with the session. The private data itself is
- * opaque to OpenCDMSession.
+ * opaque to OpenCDMSession and it lives until the lifetime of the \ref OpenCDMSession.
  *
  * \param session \ref OpenCDMSession instance.
  * \param pvtData Output parameter that will contain the Opaque private data created

--- a/Source/ocdm/ocdm.vcxproj
+++ b/Source/ocdm/ocdm.vcxproj
@@ -31,6 +31,7 @@
   <ItemGroup>
     <ClCompile Include="open_cdm.cpp" />
     <ClCompile Include="open_cdm_ext.cpp" />
+    <ClCompile Include="open_cdm_impl.cpp" />
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <VCProjectVersion>15.0</VCProjectVersion>

--- a/Source/ocdm/open_cdm.cpp
+++ b/Source/ocdm/open_cdm.cpp
@@ -283,6 +283,48 @@ OpenCDMError opencdm_system_set_server_certificate(struct OpenCDMSystem* system,
 }
 
 /**
+ * \brief Create DRM session (for actual decrypting of data).
+ *
+ * Creates an instance of \ref OpenCDMSession using initialization data.
+ * \param keySystem DRM system to create the session for.
+ * \param licenseType DRM specifc signed integer selecting License Type (e.g.
+ * "Limited Duration" for PlayReady).
+ * \param initDataType Type of data passed in \ref initData.
+ * \param initData Initialization data.
+ * \param initDataLength Length (in bytes) of initialization data.
+ * \param CDMData CDM data.
+ * \param CDMDataLength Length (in bytes) of \ref CDMData.
+ * \param session Output parameter that will contain pointer to instance of \ref
+ * OpenCDMSession.
+ * \return Zero on success, non-zero on error.
+ */
+OpenCDMError
+opencdm_construct_session(struct OpenCDMSystem* system,
+    const LicenseType licenseType, const char initDataType[],
+    const uint8_t initData[], const uint16_t initDataLength,
+    const uint8_t CDMData[], const uint16_t CDMDataLength,
+    OpenCDMSessionCallbacks* callbacks, void* userData,
+    struct OpenCDMSession** session)
+{
+    ASSERT(system != nullptr);
+    OpenCDMError result(OpenCDMError::ERROR_INVALID_SESSION);
+
+    TRACE_L1("Creating a Session for %s", system->keySystem().c_str());
+
+    result = OpenCDMSession::CreateSession(system,
+                                            licenseType,
+                                            initDataType,
+                                            initData, initDataLength,
+                                            CDMData, CDMDataLength,
+                                            callbacks, userData,
+                                            session
+    );
+
+    TRACE_L1("Created a Session, result %p, %d", *session, result);
+    return result;
+}
+
+/**
  * Destructs an \ref OpenCDMSession instance.
  * \param system \ref OpenCDMSession instance to desctruct.
  * \return Zero on success, non-zero on error.

--- a/Source/ocdm/open_cdm_ext.cpp
+++ b/Source/ocdm/open_cdm_ext.cpp
@@ -332,47 +332,6 @@ OpenCDMError opencdm_get_secure_store_hash_ext(struct OpenCDMSystem* system,
     return result;
 }
 
-/**
- * \brief Create DRM session (for actual decrypting of data).
- *
- * Creates an instance of \ref OpenCDMSession using initialization data.
- * \param keySystem DRM system to create the session for.
- * \param licenseType DRM specifc signed integer selecting License Type (e.g.
- * "Limited Duration" for PlayReady).
- * \param initDataType Type of data passed in \ref initData.
- * \param initData Initialization data.
- * \param initDataLength Length (in bytes) of initialization data.
- * \param CDMData CDM data.
- * \param CDMDataLength Length (in bytes) of \ref CDMData.
- * \param session Output parameter that will contain pointer to instance of \ref
- * OpenCDMSession.
- * \return Zero on success, non-zero on error.
- */
-OpenCDMError
-opencdm_construct_session(struct OpenCDMSystem* system,
-    const LicenseType licenseType, const char initDataType[],
-    const uint8_t initData[], const uint16_t initDataLength,
-    const uint8_t CDMData[], const uint16_t CDMDataLength,
-    OpenCDMSessionCallbacks* callbacks, void* userData,
-    struct OpenCDMSession** session)
-{
-    ASSERT(system != nullptr);
-    OpenCDMError result(ERROR_INVALID_ACCESSOR);
-
-    TRACE_L1("Creating a Session for %s", system->keySystem().c_str());
-
-    if (system != nullptr) {
-        *session = new OpenCDMSession(system, std::string(initDataType),
-                            initData, initDataLength, CDMData,
-                            CDMDataLength, licenseType, callbacks, userData);
-        result = (*session != nullptr ? OpenCDMError::ERROR_NONE
-                                      : OpenCDMError::ERROR_INVALID_SESSION);
-    }
-
-    TRACE_L1("Created a Session, result %p, %d", *session, result);
-    return result;
-}
-
 OpenCDMError opencdm_system_ext_get_properties(struct PlayLevels* system, const char* propertiesJSONText) 
 {
     using namespace Core ;

--- a/Source/ocdm/open_cdm_impl.cpp
+++ b/Source/ocdm/open_cdm_impl.cpp
@@ -68,7 +68,6 @@ class SessionPrivate {
     private:
         ConstructSessionPrivate _constructSessionPvt;
         DestructSessionPrivate _destructSessionPvt;
-        bool _bLoaded;
 };
 
 static SessionPrivate SessionPvt;

--- a/Source/ocdm/open_cdm_impl.cpp
+++ b/Source/ocdm/open_cdm_impl.cpp
@@ -75,7 +75,7 @@ class SessionPrivate {
 
 static SessionPrivate SessionPvt;
 
-OpenCDMError OpenCDMSession::CreateSession(struct OpenCDMSystem* system,
+/* static */ OpenCDMError OpenCDMSession::CreateSession(struct OpenCDMSystem* system,
                             const LicenseType licenseType, const char initDataType[],
                             const uint8_t initData[], const uint16_t initDataLength,
                             const uint8_t CDMData[], const uint16_t CDMDataLength,

--- a/Source/ocdm/open_cdm_impl.cpp
+++ b/Source/ocdm/open_cdm_impl.cpp
@@ -59,8 +59,7 @@ class SessionPrivate {
 
     private:
         void Load() {
-            const TCHAR *name = nullptr;
-            Core::Library library(name);
+            Core::Library library(&Core::System::MODULE_NAME);
             if (library.IsLoaded() == true) {
                 _constructSessionPvt = reinterpret_cast<ConstructSessionPrivate>(library.LoadFunction(_T("opencdm_construct_session_private")));
                 _destructSessionPvt = reinterpret_cast<DestructSessionPrivate>(library.LoadFunction(_T("opencdm_destruct_session_private")));

--- a/Source/ocdm/open_cdm_impl.cpp
+++ b/Source/ocdm/open_cdm_impl.cpp
@@ -42,6 +42,9 @@ class SessionPrivate {
             if(_constructSessionPvt != nullptr) {
                 result = ( _constructSessionPvt(session, pvtData) == 0 ? OpenCDMError::ERROR_NONE : OpenCDMError::ERROR_UNKNOWN);
             }
+            else {
+                pvtData = nullptr;
+            }
             return result;
         }
 
@@ -85,17 +88,14 @@ OpenCDMError OpenCDMSession::CreateSession(struct OpenCDMSystem* system,
         *session = new OpenCDMSession(system, std::string(initDataType),
                             initData, initDataLength, CDMData,
                             CDMDataLength, licenseType, callbacks, userData);
+
         result = (*session != nullptr ? OpenCDMError::ERROR_NONE
                                       : OpenCDMError::ERROR_INVALID_SESSION);
+
         if(result == OpenCDMError::ERROR_NONE) {
-            void *pvtData = nullptr;
-            (*session)->_pvtData = nullptr;
             OpenCDMError pvt_result(OpenCDMError::ERROR_METHOD_NOT_IMPLEMENTED);
-            pvt_result = SessionPvt.Construct(*session, pvtData);
-            if(pvt_result == OpenCDMError::ERROR_NONE) {
-                (*session)->_pvtData = pvtData;
-            }
-            else if(pvt_result != OpenCDMError::ERROR_METHOD_NOT_IMPLEMENTED)
+            pvt_result = SessionPvt.Construct(*session, (*session)->_pvtData);
+            if(pvt_result != OpenCDMError::ERROR_NONE && pvt_result != OpenCDMError::ERROR_METHOD_NOT_IMPLEMENTED)
             {
                 //Method is available but resulted in internal error. Not good for decryption.
                 result = OpenCDMError::ERROR_INVALID_SESSION;

--- a/Source/ocdm/open_cdm_impl.cpp
+++ b/Source/ocdm/open_cdm_impl.cpp
@@ -1,0 +1,129 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2020 Metrological
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "open_cdm_impl.h"
+
+class SessionPrivate {
+    private:
+        typedef uint32_t (*ConstructSessionPrivate)(struct OpenCDMSession*, void*&);
+        typedef uint32_t (*DestructSessionPrivate)(struct OpenCDMSession*, void*&);
+
+    public:
+        SessionPrivate(const SessionPrivate&) = delete;
+        SessionPrivate& operator= (const SessionPrivate&) = delete;
+
+        SessionPrivate()
+            : _constructSessionPvt(nullptr)
+            , _destructSessionPvt(nullptr) {
+                Load();
+        }
+        ~SessionPrivate() = default;
+
+        OpenCDMError Construct(struct OpenCDMSession* session, void* &pvtData)
+        {
+            OpenCDMError result = OpenCDMError::ERROR_METHOD_NOT_IMPLEMENTED;
+            if(_constructSessionPvt != nullptr) {
+                result = ( _constructSessionPvt(session, pvtData) == 0 ? OpenCDMError::ERROR_NONE : OpenCDMError::ERROR_UNKNOWN);
+            }
+            return result;
+        }
+
+        OpenCDMError Destruct(struct OpenCDMSession* session, void* &pvtData)
+        {
+            OpenCDMError result = OpenCDMError::ERROR_METHOD_NOT_IMPLEMENTED;
+            if(_destructSessionPvt != nullptr) {
+                result = ( _destructSessionPvt(session, pvtData) == 0 ? OpenCDMError::ERROR_NONE : OpenCDMError::ERROR_UNKNOWN);
+            }
+            return result;
+        }
+
+    private:
+        void Load() {
+            const TCHAR *name = nullptr;
+            Core::Library library(name);
+            if (library.IsLoaded() == true) {
+                _constructSessionPvt = reinterpret_cast<ConstructSessionPrivate>(library.LoadFunction(_T("opencdm_construct_session_private")));
+                _destructSessionPvt = reinterpret_cast<DestructSessionPrivate>(library.LoadFunction(_T("opencdm_destruct_session_private")));
+            }
+
+        }
+
+    private:
+        ConstructSessionPrivate _constructSessionPvt;
+        DestructSessionPrivate _destructSessionPvt;
+        bool _bLoaded;
+};
+
+static SessionPrivate SessionPvt;
+
+OpenCDMError OpenCDMSession::CreateSession(struct OpenCDMSystem* system,
+                            const LicenseType licenseType, const char initDataType[],
+                            const uint8_t initData[], const uint16_t initDataLength,
+                            const uint8_t CDMData[], const uint16_t CDMDataLength,
+                            OpenCDMSessionCallbacks* callbacks, void* userData,
+                            struct OpenCDMSession** session)
+{
+    OpenCDMError result(ERROR_INVALID_ACCESSOR);
+
+    if (system != nullptr) {
+        *session = new OpenCDMSession(system, std::string(initDataType),
+                            initData, initDataLength, CDMData,
+                            CDMDataLength, licenseType, callbacks, userData);
+        result = (*session != nullptr ? OpenCDMError::ERROR_NONE
+                                      : OpenCDMError::ERROR_INVALID_SESSION);
+        if(result == OpenCDMError::ERROR_NONE) {
+            void *pvtData;
+            OpenCDMError pvt_result(OpenCDMError::ERROR_METHOD_NOT_IMPLEMENTED);
+            pvt_result = SessionPvt.Construct(*session, pvtData);
+            if(pvt_result == OpenCDMError::ERROR_NONE) {
+                (*session)->_pvtData = pvtData;
+            }
+            else if(pvt_result != OpenCDMError::ERROR_METHOD_NOT_IMPLEMENTED)
+            {
+                //Method is available but resulted in internal error. Not good for decryption.
+                result = OpenCDMError::ERROR_INVALID_SESSION;
+                (*session)->Release();
+                *session = nullptr;
+            }
+        }
+    }
+    return result;
+}
+
+OpenCDMSession::~OpenCDMSession()
+{
+    OpenCDMAccessor* system = OpenCDMAccessor::Instance();
+
+    SessionPvt.Destruct(this, _pvtData);
+
+    system->RemoveSession(_sessionId);
+
+    if (IsValid()) {
+        _session->Revoke(&_sink);
+    }
+
+    if (_session != nullptr) {
+        Session(nullptr);
+    }
+    if (_decryptSession != nullptr) {
+        DecryptSession(nullptr);
+    }
+
+    TRACE_L1("Destructed the Session Client side: %p", this);
+}

--- a/Source/ocdm/open_cdm_impl.cpp
+++ b/Source/ocdm/open_cdm_impl.cpp
@@ -17,6 +17,7 @@
  * limitations under the License.
  */
 
+#include "Module.h"
 #include "open_cdm_impl.h"
 
 class SessionPrivate {
@@ -88,7 +89,8 @@ OpenCDMError OpenCDMSession::CreateSession(struct OpenCDMSystem* system,
         result = (*session != nullptr ? OpenCDMError::ERROR_NONE
                                       : OpenCDMError::ERROR_INVALID_SESSION);
         if(result == OpenCDMError::ERROR_NONE) {
-            void *pvtData;
+            void *pvtData = nullptr;
+            (*session)->_pvtData = nullptr;
             OpenCDMError pvt_result(OpenCDMError::ERROR_METHOD_NOT_IMPLEMENTED);
             pvt_result = SessionPvt.Construct(*session, pvtData);
             if(pvt_result == OpenCDMError::ERROR_NONE) {

--- a/Source/ocdm/open_cdm_impl.h
+++ b/Source/ocdm/open_cdm_impl.h
@@ -504,6 +504,7 @@ PUSH_WARNING(DISABLE_WARNING_THIS_IN_MEMBER_INITIALIZER_LIST)
         , _errorCode(~0)
         , _sysError(Exchange::OCDM_RESULT::OCDM_SUCCESS)
         , _system(system)
+        , _pvtData(nullptr)
     {
         OpenCDMAccessor* accessor = OpenCDMAccessor::Instance();
         std::string bufferId;
@@ -522,29 +523,18 @@ PUSH_WARNING(DISABLE_WARNING_THIS_IN_MEMBER_INITIALIZER_LIST)
         }
     }
 
+    virtual ~OpenCDMSession();
+
 POP_WARNING()
 
-    virtual ~OpenCDMSession()
-    {
-        OpenCDMAccessor* system = OpenCDMAccessor::Instance();
-
-        system->RemoveSession(_sessionId);
-
-        if (IsValid()) {
-           _session->Revoke(&_sink);
-        }
-
-        if (_session != nullptr) {
-            Session(nullptr);
-        }
-        if (_decryptSession != nullptr) {
-            DecryptSession(nullptr);
-        }
-
-        TRACE_L1("Destructed the Session Client side: %p", this);
-    }
-
 public:
+    static OpenCDMError CreateSession(struct OpenCDMSystem* system,
+                            const LicenseType licenseType, const char initDataType[],
+                            const uint8_t initData[], const uint16_t initDataLength,
+                            const uint8_t CDMData[], const uint16_t CDMDataLength,
+                            OpenCDMSessionCallbacks* callbacks, void* userData,
+                            struct OpenCDMSession** session);
+
     void AddRef() { Core::InterlockedIncrement(_refCount); }
     bool Release()
     {
@@ -651,6 +641,11 @@ public:
             }
         }
         return (result);
+    }
+
+    void* SessionPrivateData() const
+    {
+        return _pvtData;
     }
 
     uint32_t SessionIdExt() const
@@ -827,5 +822,6 @@ private:
     uint32_t _errorCode;
     Exchange::OCDM_RESULT _sysError;
     OpenCDMSystem* _system;
+    void* _pvtData;
 };
 


### PR DESCRIPTION
Session private data like SVP hardware specific context can be constructed and associated with a OCDM Session.