### PR TITLE
[Actions] Adding Cryptography with OpenSSL implementation to be built on Linux

### DIFF
--- a/.github/workflows/Build ThunderClientLibraries on Linux.yml
+++ b/.github/workflows/Build ThunderClientLibraries on Linux.yml
@@ -17,4 +17,4 @@ jobs:
 
   ThunderClientLibraries:
     needs: ThunderInterfaces
-    uses: rdkcentral/ThunderClientLibraries/.github/workflows/Linux build template.yml@master
+    uses: rdkcentral/ThunderClientLibraries/.github/workflows/Linux build template.yml@development/actions-cryptography-openssl # change back to master

--- a/.github/workflows/Build ThunderClientLibraries on Linux.yml
+++ b/.github/workflows/Build ThunderClientLibraries on Linux.yml
@@ -17,4 +17,4 @@ jobs:
 
   ThunderClientLibraries:
     needs: ThunderInterfaces
-    uses: rdkcentral/ThunderClientLibraries/.github/workflows/Linux build template.yml@development/actions-cryptography-openssl # change back to master
+    uses: rdkcentral/ThunderClientLibraries/.github/workflows/Linux build template.yml@master

--- a/.github/workflows/Linux build template.yml
+++ b/.github/workflows/Linux build template.yml
@@ -28,7 +28,7 @@ jobs:
           echo "deb http://archive.ubuntu.com/ubuntu/ jammy-updates main universe restricted multiverse" | sudo tee -a /etc/apt/sources.list
           sudo dpkg --add-architecture i386
           sudo apt-get update
-          sudo apt install python3-pip build-essential cmake ninja-build libusb-1.0-0-dev zlib1g-dev zlib1g-dev:i386 libssl-dev gcc-11-multilib g++-11-multilib
+          sudo apt install python3-pip build-essential cmake ninja-build libusb-1.0-0-dev zlib1g-dev zlib1g-dev:i386 libssl-dev libssl-dev:i386 gcc-11-multilib g++-11-multilib
           sudo pip install jsonref
 
     - name: Download artifacts

--- a/.github/workflows/Linux build template.yml
+++ b/.github/workflows/Linux build template.yml
@@ -63,6 +63,8 @@ jobs:
         -DCMAKE_INSTALL_PREFIX="${{matrix.build_type}}/install/usr" \
         -DCMAKE_MODULE_PATH="${PWD}/${{matrix.build_type}}/install/usr/include/WPEFramework/Modules" \
         -DBLUETOOTHAUDIOSINK=ON \
+        -DCRYPTOGRAPHY=ON \
+        -DCRYPTOGRAPHY_IMPLEMENTATION="OpenSSL" \
         -DDEVICEINFO=ON \
         -DDISPLAYINFO=ON \
         -DLOCALTRACER=ON \

--- a/.github/workflows/Linux build template.yml
+++ b/.github/workflows/Linux build template.yml
@@ -61,6 +61,7 @@ jobs:
 # ----- Building & uploading -----
     - name: Build ThunderClientLibraries
       run: |
+        ${{matrix.architecture == '32' && 'export PKG_CONFIG_PATH=/usr/lib/i386-linux-gnu/pkgconfig:$PKG_CONFIG_PATH' || ':'}}
         cmake -G Ninja -S ThunderClientLibraries -B ${{matrix.build_type}}/build/ThunderClientLibraries \
         -DCMAKE_CXX_FLAGS="-Wall -Wextra -Wpedantic -Werror -m${{matrix.architecture}}" \
         -DCMAKE_C_FLAGS="-Wall -Wextra -Wpedantic -Werror -m${{matrix.architecture}}" \

--- a/.github/workflows/Linux build template.yml
+++ b/.github/workflows/Linux build template.yml
@@ -15,7 +15,7 @@ jobs:
 
     name: Build type - ${{matrix.build_type}}${{matrix.architecture == '32' && ' x86' || ''}}
     steps:
-# --------- Packages & articats ---------
+# --------- Packages & artifacts ---------
     - name: Install necessary packages
       uses: nick-fields/retry@v3
       with:

--- a/.github/workflows/Linux build template.yml
+++ b/.github/workflows/Linux build template.yml
@@ -26,9 +26,9 @@ jobs:
           sudo apt-spy2 fix --commit --launchpad --country=US
           echo "deb http://archive.ubuntu.com/ubuntu/ jammy main universe restricted multiverse" | sudo tee -a /etc/apt/sources.list
           echo "deb http://archive.ubuntu.com/ubuntu/ jammy-updates main universe restricted multiverse" | sudo tee -a /etc/apt/sources.list
-          sudo dpkg --add-architecture i386
+          ${{matrix.architecture == '32' && 'sudo dpkg --add-architecture i386' || ':'}}
           sudo apt-get update
-          sudo apt install python3-pip build-essential cmake ninja-build libusb-1.0-0-dev zlib1g-dev zlib1g-dev:i386 libssl-dev libssl-dev:i386 gcc-11-multilib g++-11-multilib
+          sudo apt install python3-pip build-essential cmake ninja-build libusb-1.0-0-dev ${{matrix.architecture == '32' && 'zlib1g-dev:i386 libssl-dev:i386 gcc-11-multilib g++-11-multilib' || 'zlib1g-dev libssl-dev'}}
           sudo pip install jsonref
 
     - name: Download artifacts


### PR DESCRIPTION
A while ago someone noticed a compilation error with Cryptography locally, and we decided it is worth to try to add it into Actions, so this Jira ticket was created: https://jira.rdkcentral.com/jira/browse/METROL-1033

Originally, over a year ago, it was not possible due to some compilation errors, but it looks like it has been long resolved. So, after making sure correct libraries are installed and linked for both 32-bit and 64-bit, Cryptography with OpenSSL implementation is now built in the Linux actions.