### PR TITLE
RDK-53576 OCDM client l2test framework

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,8 @@ option(CRYPTOGRAPHY
 
 option(INSTALL_TESTS "Install the test applications" OFF)
 
+option(L2_TESTS "Install the test applications" OFF)
+
 if (BUILD_REFERENCE)
     add_definitions (-DBUILD_REFERENCE=${BUILD_REFERENCE})
 endif()

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -19,4 +19,9 @@ if(CDMI)
     add_subdirectory(ocdmtest)
 endif()
 
+if(L2_TESTS)
+    add_subdirectory(L2Tests)
+endif()
+
+
 

--- a/Tests/L2Tests/CMakeLists.txt
+++ b/Tests/L2Tests/CMakeLists.txt
@@ -1,0 +1,56 @@
+# If not stated otherwise in this file or this component's LICENSE file the
+# following copyright and licenses apply:
+#
+# Copyright 2024 RDK Management
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.8)
+project(L2Test)
+
+set(CMAKE_CXX_STANDARD 11)
+
+find_package(Thunder)
+find_package(ClientOCDM REQUIRED)
+find_package(${NAMESPACE}Core REQUIRED)
+find_package(${NAMESPACE}COM REQUIRED)
+find_package(${NAMESPACE}Messaging REQUIRED)
+find_package(CompileSettingsDebug CONFIG REQUIRED)
+find_package(GTest REQUIRED)
+include(CTest)
+
+file(GLOB TESTS tests/*.cpp)
+
+add_executable(${PROJECT_NAME}
+	gtest_main.cpp
+        ${TESTS}
+        )
+
+include_directories(../../Source/ocdm)
+link_directories(../../Source/ocdm)
+
+target_link_libraries(${PROJECT_NAME}
+	${NAMESPACE}Core::${NAMESPACE}Core
+	${NAMESPACE}COM::${NAMESPACE}COM
+	${NAMESPACE}Messaging::${NAMESPACE}Messaging
+        CompileSettingsDebug::CompileSettingsDebug
+	ClientOCDM::ClientOCDM
+	GTest::GTest
+        )
+
+gtest_add_tests(TARGET ${PROJECT_NAME})
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage")
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --coverage")
+
+install(TARGETS ${PROJECT_NAME} DESTINATION bin)

--- a/Tests/L2Tests/gtest_main.cpp
+++ b/Tests/L2Tests/gtest_main.cpp
@@ -1,0 +1,26 @@
+/*
+* If not stated otherwise in this file or this component's license file the
+* following copyright and licenses apply:
+*
+* Copyright 2024 RDK Management
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include <gtest/gtest.h>
+
+int main(int argc, char** argv)
+{
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/Tests/L2Tests/run.sh
+++ b/Tests/L2Tests/run.sh
@@ -1,0 +1,26 @@
+#!/bin/bash 
+# This script will build and run the L2 tests
+
+rm -rf build 
+
+mkdir build
+
+cd build
+
+export GTEST_OUTPUT="json"
+
+cmake ..
+
+make
+
+./L2Test
+
+#Generate coverage report
+if [ "$1" != "" ] && [ $1 = "-c" ]; then
+	lcov --capture --directory . --output-file coverage.info
+	lcov --remove coverage.info '/usr/*' --output-file coverage.info
+	lcov --list coverage.info
+	genhtml coverage.info --output-directory coverage_report
+fi
+
+

--- a/Tests/L2Tests/tests/open_cdm_ext_tests.cpp
+++ b/Tests/L2Tests/tests/open_cdm_ext_tests.cpp
@@ -1,0 +1,42 @@
+/*
+* If not stated otherwise in this file or this component's license file the
+* following copyright and licenses apply:
+*
+* Copyright 2024 RDK Management
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "open_cdm_impl.h"
+#include "open_cdm_ext.h"
+#include <gtest/gtest.h>
+using namespace testing;
+
+class OpenCDMExt_Test : public ::testing::Test {
+protected:
+
+    void SetUp() override {
+    }
+
+    void TearDown() override {
+        }
+};
+
+TEST_F(OpenCDMExt_Test, opencdm_CreateSystem)
+{
+	int status = 0;
+	const char keySystem[] = "playready";
+	struct OpenCDMSystem* result;
+	result = opencdm_create_system(keySystem);
+	EXPECT_EQ(result, nullptr);
+}


### PR DESCRIPTION
Reason for change : L2 test framework for ocdm and run scripts added
Test procedure: Run run.sh and check l2 tests are executed and reports generated
Risks: Low
Signed-off-by: nkader321 <NoorjahanRofina_KaderMohideen@comcast.com>