### PR TITLE
[CRYPTOGRAPHY] For windows we *must* inlude the crapthalgo it is usin…

### DIFF
--- a/Source/cryptography/Module.h
+++ b/Source/cryptography/Module.h
@@ -24,8 +24,9 @@
 #endif
 
 #include <core/core.h>
-#include <messaging/messaging.h>
 #include <com/com.h>
+#include <messaging/messaging.h>
+#include <cryptalgo/cryptalgo.h>
 
 #if defined(__WINDOWS__) 
 #if defined(CRYPTOGRAPHY_EXPORTS)


### PR DESCRIPTION
…g so the lib gets linked in.