### PR TITLE
TDK-10018 : Enhance Cryptography Interface tests

### DIFF
--- a/Source/cryptography/tests/cryptography_test/InterfaceTests.cpp
+++ b/Source/cryptography/tests/cryptography_test/InterfaceTests.cpp
@@ -334,6 +334,7 @@ int main(int argc, char **argv)
 {
     cg = Thunder::Exchange::ICryptography::Instance("");
     int len;
+    bool instance_set = false;
     if (cg != nullptr) {
 
 	for( int i= 1; i < argc; ++i )
@@ -343,16 +344,19 @@ int main(int argc, char **argv)
             {
 		 printf("\nAcquiring Netflix instance\n");
                  vault = cg->Vault(Thunder::Exchange::CryptographyVault::CRYPTOGRAPHY_VAULT_NETFLIX);
+		 instance_set = true;
             }
 	    else if ( (len == 9) && !strncmp( (const char*)argv[i], "--default", len) )
             {
 		 printf("\nAcquiring DEFAULT instance\n");
 	         vault = cg->Vault(Thunder::Exchange::CryptographyVault::CRYPTOGRAPHY_VAULT_DEFAULT);
+		 instance_set = true;
             }
 	    else if ( (len == 10) && !strncmp( (const char*)argv[i], "--platform", len) )
             {
 		 printf("\nAcquiring PLATFORM instance\n");
 		 vault = cg->Vault(Thunder::Exchange::CryptographyVault::CRYPTOGRAPHY_VAULT_PLATFORM);
+		 instance_set = true;
 	    }
 	    else if ( (len == 21) && !strncmp( (const char*)argv[i], "--testdefaultinstance", len) )
             {
@@ -363,9 +367,10 @@ int main(int argc, char **argv)
 		 printf("\nAcquiring PLATFORM instance\n");
 		 vault = cg->Vault(Thunder::Exchange::CryptographyVault::CRYPTOGRAPHY_VAULT_PLATFORM);
 #endif
+		 instance_set = true;
 	     }
         }
-	if (vault == nullptr)
+	if ((vault == nullptr) && (!instance_set))
 	    vault = cg->Vault(Thunder::Exchange::CryptographyVault::CRYPTOGRAPHY_VAULT_NETFLIX);
 
         if (vault != nullptr) {


### PR DESCRIPTION
For cgfacetests - 
Source code - Source/cryptography/tests/cryptography_test/InterfaceTests.cpp

There is provision to test for different vault instances - using command line options
-netflix 
--default
--platform
--testdefaultinstance

However if the test fails to obtain the provided instance, the error is not captured and test proceeds to obtain CRYPTOGRAPHY_VAULT_NETFLIX.

Handle this by setting a flag incase command line option is provided