### PR TITLE
RDK-56907 SecAPI key to encrypt and save user credentials

### DIFF
--- a/Source/cryptography/implementation/SecApi/Vault.h
+++ b/Source/cryptography/implementation/SecApi/Vault.h
@@ -33,7 +33,7 @@
 #include "persistent_implementation.h"
 
 #define globalDir "/opt/drm/"
-#define appDir "/opt/drm/vault/"  //TODO:To get this path from client
+#define appDir "/home/private/persist/"  //TODO:To get this path from client
 
 #define DH_PUBLIC_KEY_MAX    (129)
 #define KEYLEN_AES_HMAC_128  (16)


### PR DESCRIPTION
Reason for change: To store the user credentials
Test Procedure: Launch the amazon native app and re-launch it
Risks: Low
Priority: P1
Signed-off-by: vidhathri_joshi@comcast.com