### PR TITLE
Development/compositor modifier enhancements

### DIFF
--- a/Source/compositorclient/src/Mesa/CMakeLists.txt
+++ b/Source/compositorclient/src/Mesa/CMakeLists.txt
@@ -53,3 +53,5 @@ target_compile_definitions(${PLUGIN_COMPOSITOR_IMPLEMENTATION}
     PUBLIC
         EGL_NO_X11
     )
+
+add_subdirectory(test)

--- a/Source/compositorclient/src/Mesa/Implementation.cpp
+++ b/Source/compositorclient/src/Mesa/Implementation.cpp
@@ -139,16 +139,13 @@ namespace Linux {
                 {
                     ASSERT(_bo != nullptr);
 
-                    if (frameBuffer != nullptr) {
-                        uint16_t planes = gbm_bo_get_plane_count(frameBuffer);
+                    if (_bo != nullptr) {
+                        // for now only single plane buffers are supported
+                        ASSERT(gbm_bo_get_plane_count(_bo) == 1); 
 
-                        ASSERT(planes == 1); // for now only single plane buffers are supported
-
-                        const uint8_t index = 0; // only single plane supported
-
-                        Add(gbm_bo_get_fd_for_plane(frameBuffer, index),
-                            gbm_bo_get_stride_for_plane(frameBuffer, index),
-                            gbm_bo_get_offset(frameBuffer, index));
+                        Add(gbm_bo_get_fd_for_plane(_bo, 0),
+                            gbm_bo_get_stride_for_plane(_bo, 0),
+                            gbm_bo_get_offset(_bo, 0));
 
                         std::array<int, Core::PrivilegedRequest::MaxDescriptorsPerRequest> descriptors;
                         descriptors.fill(-1);

--- a/Source/compositorclient/src/Mesa/Implementation.cpp
+++ b/Source/compositorclient/src/Mesa/Implementation.cpp
@@ -66,6 +66,34 @@ namespace Linux {
             }
             return connector;
         }
+
+        constexpr std::array<uint32_t, 5> FormatPriority = {
+            DRM_FORMAT_ARGB8888, // Best overall - universal support with full alpha
+            DRM_FORMAT_ABGR8888, // Alternative byte order, still 32-bit and full alpha
+            DRM_FORMAT_XRGB8888, // Best for opaque content
+            DRM_FORMAT_XBGR8888, // Alternative opaque format
+            DRM_FORMAT_RGB565 // Fallback - memory efficient, widely supported
+        };
+
+        const char* GetGbmBackendName(gbm_device* gbmDevice)
+        {
+            static gbm_device* cachedDevice = nullptr;
+            static const char* cachedName = nullptr;
+
+            if (gbmDevice != nullptr && gbmDevice != cachedDevice) {
+                cachedName = gbm_device_get_backend_name(gbmDevice);
+                cachedDevice = gbmDevice;
+                TRACE_GLOBAL(Trace::Information, (_T("GBM Backend: %s"), cachedName));
+            }
+            return cachedName;
+        }
+
+        bool IsGbmBackend(gbm_device* gbmDevice, const char* name)
+        {
+            const char* backendName = GetGbmBackendName(gbmDevice);
+            return (backendName != nullptr) && (strcmp(backendName, name) == 0);
+        }
+
     }
 
     class Display : public Compositor::IDisplay {
@@ -704,9 +732,39 @@ namespace Linux {
             _adminLock.Unlock();
         }
 
-        Thunder::Exchange::IComposition::IClient* CreateRemoteSurface(const std::string& name, const uint32_t width, const uint32_t height)
+        Exchange::IComposition::IClient* CreateRemoteSurface(const std::string& name, const uint32_t width, const uint32_t height)
         {
             return (_remoteDisplay != nullptr ? _remoteDisplay->CreateClient(name, width, height) : nullptr);
+        }
+        
+        gbm_surface* CreateGbmSurface(const uint32_t width, const uint32_t height) const
+        {
+            gbm_surface* surface(nullptr);
+
+            uint32_t usage(0);
+
+            if (IsGbmBackend(static_cast<gbm_device*>(_gbmDevice), "nvidia") == false) {
+                usage |= GBM_BO_USE_RENDERING; // the nvidia backend seems to have issues with usage flags....
+            }
+
+            for (uint32_t format : FormatPriority) {
+                char* formatName = drmGetFormatName(format);
+
+                ASSERT(formatName != nullptr); // Should always be valid for known DRM formats
+
+                surface = gbm_surface_create(_gbmDevice, width, height, format, usage);
+                if (surface != nullptr) {
+                    TRACE(Trace::Information, ("Successfully created surface with format: %s", formatName ? formatName : "Unknown"));
+                    break;
+                }
+                TRACE(Trace::Warning, ("Failed to create GBM surface with format: %s, trying next...", formatName ? formatName : "Unknown"));
+
+                if (formatName != nullptr) {
+                    free(formatName);
+                }
+            }
+
+            return surface;
         }
 
     private:

--- a/Source/compositorclient/src/Mesa/Implementation.cpp
+++ b/Source/compositorclient/src/Mesa/Implementation.cpp
@@ -121,168 +121,80 @@ namespace Linux {
 
         class SurfaceImplementation : public Compositor::IDisplay::ISurface {
         private:
-
-            class GBMSurface : public Graphics::ClientBufferType<1> {
-            private:
+            // for now only single plane buffers are supported, e.g. GBM_FORMAT_ARGB8888, GBM_FORMAT_XRGB8888, etc.
+            class ContentBuffer : public Graphics::ClientBufferType<1> {
                 using BaseClass = Graphics::ClientBufferType<1>;
 
-            private:
-                static void Destroyed(gbm_bo* bo VARIABLE_IS_NOT_USED, void* data VARIABLE_IS_NOT_USED)
-                {
-                }
-
-                gbm_bo* Lock(const uint16_t ms)
-                {
-                    gbm_bo* frameBuffer = nullptr;
-
-                    if (_bufferLock.try_lock_for(std::chrono::milliseconds(ms))) {
-                        frameBuffer = gbm_surface_lock_front_buffer(_surface);
-
-                        if (frameBuffer == nullptr) {
-                            _bufferLock.unlock(); // Unlock the mutex to prevent deadlock
-                            TRACE(Trace::Error, (_T("Failed to lock front buffer, surface %p"), _surface));
-                        } else {
-                            TRACE(Trace::Information, (_T("Acquired framebuffer[%p]"), frameBuffer));
-                        }
-                    } else {
-                        TRACE(Trace::Error, (_T("Failed to lock front buffer within %d ms"), ms));
-                    }
-
-                    return frameBuffer;
-                }
-
-                void Unlock(gbm_bo* frameBuffer)
-                {
-                    ASSERT((_surface != nullptr) && "Failed to release framebuffer, surface is null");
-
-                    if (_surface != nullptr) {
-                        gbm_surface_release_buffer(_surface, frameBuffer);
-                        TRACE(Trace::Information, (_T("Released framebuffer[%p]"), frameBuffer));
-                    }
-
-                    _bufferLock.unlock();
-                }
-
             public:
-                GBMSurface(SurfaceImplementation& parent, gbm_device* gbmDevice, uint32_t remoteId)
-                    : BaseClass()
+                ContentBuffer() = delete;
+                ContentBuffer(ContentBuffer&&) = delete;
+                ContentBuffer(const ContentBuffer&) = delete;
+                ContentBuffer& operator=(ContentBuffer&&) = delete;
+                ContentBuffer& operator=(const ContentBuffer&) = delete;
+
+                ContentBuffer(SurfaceImplementation& parent, gbm_bo* frameBuffer)
+                    : BaseClass(gbm_bo_get_width(frameBuffer), gbm_bo_get_height(frameBuffer), gbm_bo_get_format(frameBuffer), gbm_bo_get_modifier(frameBuffer), Exchange::IGraphicsBuffer::TYPE_DMA)
                     , _parent(parent)
-                    , _remoteId(remoteId)
-                    , _surface(nullptr)
-                    , _frameBuffer(nullptr)
-                    , _bufferLock()
+                    , _bo(frameBuffer)
                 {
-                    ASSERT(gbmDevice != nullptr);
+                    ASSERT(_bo != nullptr);
 
-                    Core::PrivilegedRequest::Container descriptors;
-                    Core::PrivilegedRequest request;
+                    if (frameBuffer != nullptr) {
+                        uint16_t planes = gbm_bo_get_plane_count(frameBuffer);
 
-                    const string connector = ConnectorPath() + _T("descriptors");
+                        ASSERT(planes == 1); // for now only single plane buffers are supported
 
-                    if (request.Request(100, connector, _remoteId, descriptors) == Core::ERROR_NONE) {
-                        Load(descriptors);
-                    } else {
-                        TRACE(Trace::Error, (_T ( "Failed to get display file descriptor from compositor server")));
-                    }
+                        const uint8_t index = 0; // only single plane supported
 
-                    ASSERT(Format() != DRM_FORMAT_INVALID);
+                        Add(gbm_bo_get_fd_for_plane(frameBuffer, index),
+                            gbm_bo_get_stride_for_plane(frameBuffer, index),
+                            gbm_bo_get_offset(frameBuffer, index));
 
-                    uint32_t flags = GBM_BO_USE_RENDERING;
+                        std::array<int, Core::PrivilegedRequest::MaxDescriptorsPerRequest> descriptors;
+                        descriptors.fill(-1);
 
-                    const uint64_t modifier(Modifier());
+                        const uint8_t nDescriptors = Descriptors(descriptors.size(), descriptors.data());
 
-                    if (modifier == DRM_FORMAT_MOD_INVALID) {
-                        flags |= GBM_BO_USE_LINEAR;
-                        _surface = gbm_surface_create(gbmDevice, Width(), Height(), Format(), flags);
-                    } else {
-                        _surface = gbm_surface_create_with_modifiers2(gbmDevice, Width(), Height(), Format(), &modifier, 1, flags);
-                    }
+                        if (nDescriptors > 0) {
+                            Core::PrivilegedRequest::Container container(descriptors.begin(), descriptors.begin() + nDescriptors);
+                            Core::PrivilegedRequest request;
+                            
+                            const string connector = ConnectorPath() + _T("descriptors");
 
-                    ASSERT(_surface != nullptr);
-                }
-
-                ~GBMSurface()
-                {
-                    if (_frameBuffer != nullptr) {
-                        gbm_surface_release_buffer(_surface, _frameBuffer);
-                        _frameBuffer = nullptr;
-                    }
-
-                    if (_surface != nullptr) {
-                        gbm_surface_destroy(_surface);
-                        _surface = nullptr;
-                    }
-                }
-
-                void SetUserData(gbm_bo* frameBuffer)
-                {
-                    static bool userdataSet(false);
-
-                    if (userdataSet) {
-                        ASSERT(false && "User data already set for this frame buffer");
-                        return;
-                    }
-
-                    ASSERT(frameBuffer != nullptr);
-
-                    uint16_t planes = gbm_bo_get_plane_count(frameBuffer);
-
-                    Core::PrivilegedRequest::Container descriptors;
-                    Core::PrivilegedRequest request;
-
-                    for (uint16_t index = 0; index < planes; index++) {
-                        int descriptor = gbm_bo_get_fd_for_plane(frameBuffer, index);
-                        descriptors.emplace_back(descriptor);
-                        Add(descriptor, gbm_bo_get_stride_for_plane(frameBuffer, index), gbm_bo_get_offset(frameBuffer, index));
-                    }
-
-                    const string connector = ConnectorPath() + _T("descriptors");
-
-                    if (request.Offer(100, connector, _remoteId, descriptors) == Core::ERROR_NONE) {
-                        TRACE(Trace::Information, (_T("Offered buffer to compositor server")));
-                    } else {
-                        TRACE(Trace::Error, (_T("Failed to offer buffer to compositor server")));
-                    }
-
-                    gbm_bo_set_user_data(frameBuffer, this, &Destroyed);
-                    userdataSet = true;
-                }
-
-                bool RenderError()
-                {
-                    std::this_thread::sleep_for(std::chrono::milliseconds(5));
-                    Rendered(); // we still need call Rendered to request a new frame buffer
-                    return false; // indicate that we failed to render
-                }
-
-                bool Render()
-                {
-                    bool result = true;
-                    gbm_bo* frameBuffer = Lock(1000);
-
-                    if (frameBuffer == nullptr) {
-                        result = RenderError(); // bail-out if we cannot lock the front buffer
-                    } else {
-                        if ((_frameBuffer != nullptr && _frameBuffer != frameBuffer)) {
-                            ASSERT(false && "New FrameBuffer DETECTED, this should not happen!");
-                            return RenderError(); // bail-out if we already have a frame buffer.
+                            if (request.Offer(100, connector, parent.Id(), container) == Core::ERROR_NONE) {
+                                TRACE(Trace::Information, (_T("Offered buffer to compositor server")));
+                            } else {
+                                TRACE(Trace::Error, (_T("Failed to offer buffer to compositor server")));
+                            }
                         }
-
-                        if (gbm_bo_get_user_data(frameBuffer) == nullptr) {
-                            SetUserData(frameBuffer);
-                        }
-
-                        _frameBuffer = frameBuffer;
-
-                        RequestRender();
                     }
 
-                    return result;
+                    Core::ResourceMonitor::Instance().Register(*this);
                 }
 
+                virtual ~ContentBuffer()
+                {
+                    Core::ResourceMonitor::Instance().Unregister(*this);
+                };
+
+                static void Destroyed(gbm_bo* bo, void* data)
+                {
+                    ASSERT(data != nullptr);
+                    ContentBuffer* buffer = static_cast<ContentBuffer*>(data);
+
+                    TRACE_GLOBAL(Trace::Information, (_T("ContentBuffer[%p] Destroyed signaled"), buffer));
+
+                    if ((buffer != nullptr) && (bo == buffer->_bo)) {
+                        delete buffer;
+                    } else {
+                        TRACE_GLOBAL(Trace::Error, (_T("ContentBuffer[%p] Destroyed signaled with mismatched gbm_bo[%p]"), buffer, bo));
+                    }
+                }
+
+            protected:
                 void Rendered() override
                 {
-                    Unlock(_frameBuffer);
+                    _parent.Unlock(_bo);
                     _parent.Rendered();
                 }
 
@@ -291,17 +203,9 @@ namespace Linux {
                     _parent.Published();
                 }
 
-                EGLNativeWindowType Native() const
-                {
-                    return static_cast<EGLNativeWindowType>(_surface);
-                }
-
             private:
                 SurfaceImplementation& _parent;
-                uint32_t _remoteId;
-                gbm_surface* _surface;
-                gbm_bo* _frameBuffer;
-                std::timed_mutex _bufferLock;
+                gbm_bo* _bo;
             };
 
         public:
@@ -312,11 +216,14 @@ namespace Linux {
             SurfaceImplementation& operator=(const SurfaceImplementation&) = delete;
 
             SurfaceImplementation(Display& display, const std::string& name, const uint32_t width, const uint32_t height, ICallback* callback)
-                : _id(Core::InterlockedIncrement(_surfaceIndex))
-                , _display(display)
+                : _display(display)
+                , _gbmSurface(display.CreateGbmSurface(width, height))
                 , _remoteClient(display.CreateRemoteSurface(name, width, height))
-                , _surface(*this, static_cast<gbm_device*>(_display.Native()), _remoteClient->Native())
-                , _name(_remoteClient->Name())
+                , _id(_remoteClient->Native())
+                , _width(width)
+                , _height(height)
+                , _gbmBufferLock()
+                , _name(name)
                 , _keyboard(nullptr)
                 , _wheel(nullptr)
                 , _pointer(nullptr)
@@ -326,17 +233,15 @@ namespace Linux {
                 _display.AddRef();
 
                 ASSERT(_remoteClient != nullptr);
-                TRACE(Trace::Information, (_T("Construct surface[%d] %s  %dx%d (hxb)"), _id, name.c_str(), height, width));
+                ASSERT(_gbmSurface != nullptr);
 
-                Core::ResourceMonitor::Instance().Register(_surface);
+                TRACE(Trace::Information, (_T("Construct surface[%d] %s  %dx%d (hxb)"), _id, name.c_str(), height, width));
 
                 _display.Register(this);
             }
             ~SurfaceImplementation() override
             {
                 _display.Unregister(this);
-
-                Core::ResourceMonitor::Instance().Unregister(_surface);
 
                 if (_keyboard != nullptr) {
                     _keyboard->Release();
@@ -359,13 +264,54 @@ namespace Linux {
                     _remoteClient->Release();
                 }
 
+                // lets hope DRM cleans up the gbm buffer objects for us, if so drm should call ContentBuffer::Destroyed()...
+                if (_gbmSurface != nullptr) {
+                    gbm_surface_destroy(_gbmSurface);
+                    _gbmSurface = nullptr;
+                }
+
                 _display.Release();
+            }
+
+        private:
+            gbm_bo* Lock(const uint16_t ms)
+            {
+                ASSERT((_gbmSurface != nullptr) && "Failed to lock a framebuffer, surface is null");
+
+                gbm_bo* frameBuffer = nullptr;
+
+                if (_gbmBufferLock.try_lock_for(std::chrono::milliseconds(ms))) {
+                    frameBuffer = gbm_surface_lock_front_buffer(_gbmSurface);
+
+                    if (frameBuffer == nullptr) {
+                        _gbmBufferLock.unlock(); // Unlock the mutex to prevent deadlock
+                        TRACE(Trace::Error, (_T("Failed to lock front buffer, surface %p"), _gbmSurface));
+                    } else {
+                        TRACE(Trace::Information, (_T("Acquired framebuffer[%p]"), frameBuffer));
+                    }
+                } else {
+                    TRACE(Trace::Error, (_T("Failed to lock front buffer within %d ms"), ms));
+                }
+
+                return frameBuffer;
+            }
+
+            void Unlock(gbm_bo* frameBuffer)
+            {
+                ASSERT((_gbmSurface != nullptr) && "Failed to release framebuffer, surface is null");
+
+                if ((_gbmSurface != nullptr) && (frameBuffer != nullptr)) {
+                    gbm_surface_release_buffer(_gbmSurface, frameBuffer);
+                    TRACE(Trace::Information, (_T("Released framebuffer[%p]"), frameBuffer));
+                }
+
+                _gbmBufferLock.unlock();
             }
 
         public:
             EGLNativeWindowType Native() const override
             {
-                return _surface.Native();
+                return static_cast<EGLNativeWindowType>(_gbmSurface);
             }
             std::string Name() const override
             {
@@ -433,11 +379,11 @@ namespace Linux {
             }
             int32_t Width() const override
             {
-                return _surface.Width();
+                return _width; // not sure if we need to return the real height or the scaled height
             }
             int32_t Height() const override
             {
-                return _surface.Height();
+                return _height; // not sure if we need to return the real height or the scaled height
             }
             inline void SendKey(const uint32_t key, const IKeyboard::state action, const uint32_t timestamp VARIABLE_IS_NOT_USED)
             {
@@ -486,7 +432,23 @@ namespace Linux {
 
             void RequestRender() override
             {
-                _surface.Render();
+                gbm_bo* frameBuffer = Lock(1000);
+
+                if (frameBuffer == nullptr) {
+                    // bail-out if we cannot lock the front buffer
+                    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+                    Rendered(); // we still need call Rendered to request a new frame buffer
+                } else {
+                    ContentBuffer* buffer = static_cast<ContentBuffer*>(gbm_bo_get_user_data(frameBuffer));
+
+                    if (buffer == nullptr) {
+                        buffer = new ContentBuffer(*this, frameBuffer);
+                        gbm_bo_set_user_data(frameBuffer, buffer, &ContentBuffer::Destroyed);
+                    }
+
+                    ASSERT(buffer != nullptr);
+                    buffer->RequestRender();
+                }
             }
 
             uint32_t Process()
@@ -495,10 +457,13 @@ namespace Linux {
             }
 
         private:
-            const uint8_t _id;
             Display& _display;
+            gbm_surface* _gbmSurface;
             Exchange::IComposition::IClient* _remoteClient;
-            GBMSurface _surface;
+            const uint8_t _id;
+            const int32_t _width; // real pixels allocated in the gpu!
+            const int32_t _height; // real pixels allocated in the gpu
+            std::timed_mutex _gbmBufferLock;
             const string _name;
             IKeyboard* _keyboard;
             IWheel* _wheel;

--- a/Source/compositorclient/src/Mesa/test/CMakeLists.txt
+++ b/Source/compositorclient/src/Mesa/test/CMakeLists.txt
@@ -1,0 +1,42 @@
+# If not stated otherwise in this file or this component's license file the
+# following copyright and licenses apply:
+#
+# Copyright 2023 Metrological
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+find_package(CompileSettingsDebug CONFIG REQUIRED)
+find_package(gbm REQUIRED)
+find_package(libdrm REQUIRED)
+find_package(EGL REQUIRED)
+
+add_executable(gbm_buffer_test gbm_buffer_test.cpp)
+
+# Set target properties
+set_target_properties(gbm_buffer_test PROPERTIES
+    CXX_STANDARD 11
+    CXX_STANDARD_REQUIRED ON
+    CXX_EXTENSIONS OFF
+    OUTPUT_NAME gbm_buffer_test
+)
+
+target_link_libraries(gbm_buffer_test
+    PRIVATE
+        CompileSettingsDebug::CompileSettingsDebug
+        libdrm::libdrm
+        gbm::gbm
+        EGL::EGL
+)
+
+install(TARGETS gbm_buffer_test DESTINATION ${CMAKE_INSTALL_BINDIR}/${NAMESPACE}Tests COMPONENT ${NAMESPACE}_Test)
+

--- a/Source/compositorclient/src/Mesa/test/gbm_buffer_test.cpp
+++ b/Source/compositorclient/src/Mesa/test/gbm_buffer_test.cpp
@@ -1,0 +1,367 @@
+#include <gbm.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <iostream>
+#include <vector>
+#include <thread>
+#include <chrono>
+#include <cstring>
+#include <string>
+#include <sstream>
+
+#include <xf86drm.h>
+#include <xf86drmMode.h>
+#include <drm_fourcc.h>
+
+#define EGL_EGLEXT_PROTOTYPES
+#include <EGL/egl.h>
+#include <EGL/eglext.h>
+
+/**
+ * @class SimpleGBMTest
+ * @brief A utility class for testing GBM buffer management and EGL integration.
+ *
+ * This class encapsulates the initialization and management of GBM (Generic Buffer Management)
+ * devices and surfaces, as well as EGL context and surface creation for rendering. It provides
+ * functionality to test buffer reuse, inspect buffer file descriptors, and retrieve buffer
+ * information such as format, modifier, size, and stride.
+ *
+ * Internal buffer objects are managed via the BufferObject struct, which wraps a GBM buffer
+ * object and its associated file descriptor, providing validity checks and cleanup logic.
+ *
+ * Key Features:
+ * - Initialize a DRM device and create a GBM device/surface.
+ * - Set up EGL display, context, and surface for rendering.
+ * - Test buffer reuse across multiple iterations, tracking buffer validity and reuse status.
+ * - Inspect and validate buffer file descriptors using DRM ioctl calls.
+ * - Retrieve detailed buffer information for debugging and analysis.
+ *
+ * Usage:
+ * 1. Call Initialize() with the DRM device path to set up GBM and EGL.
+ * 2. Use TestBufferReuse() to perform buffer reuse tests.
+ * 3. The destructor automatically cleans up all resources.
+ *
+ * Thread Safety: Not thread-safe.
+ *
+ * Dependencies:
+ * - GBM (libgbm)
+ * - EGL (libEGL)
+ * - DRM (libdrm)
+ * - POSIX (unistd, fcntl)
+ */
+class SimpleGBMTest {
+private:
+    struct BufferObject {
+        int fd;
+        gbm_bo* boPtr;
+
+        explicit BufferObject(gbm_bo* bo)
+            : fd((bo != nullptr) ? gbm_bo_get_fd(bo) : -1)
+            , boPtr(bo)
+        {
+        }
+
+        ~BufferObject()
+        {
+            // Only close if it is valid and not owned elsewhere
+            if (fd >= 0) {
+                close(fd);
+            }
+            boPtr = nullptr;
+        }
+
+        bool IsValid() const
+        {
+            return (fd >= 0) && (boPtr != nullptr);
+        }
+
+        static void Destroy(gbm_bo* bo, void* data)
+        {
+            if (!data)
+                return;
+            auto* buffer = static_cast<BufferObject*>(data);
+            if (bo != buffer->boPtr) {
+                std::cout << "Warning: destroying mismatched buffer!" << std::endl;
+            }
+            delete buffer;
+        }
+
+        bool CheckFd() const
+        {
+            return (fd >= 0) && (fcntl(fd, F_GETFL) != -1);
+        }
+    };
+
+    bool InspectGbmFd(int dmaFd) const
+    {
+        drm_prime_handle args{};
+        args.handle = 0;
+        args.flags = 0; // just validity check
+        args.fd = dmaFd;
+
+        if (drmIoctl(_drmFd, DRM_IOCTL_PRIME_FD_TO_HANDLE, &args) < 0) {
+            std::cerr << "InspectGbmFd: " << std::strerror(errno) << "\n";
+            return false;
+        }
+
+        drm_gem_close close_args{};
+        close_args.handle = args.handle;
+        drmIoctl(_drmFd, DRM_IOCTL_GEM_CLOSE, &close_args);
+        return true;
+    }
+
+    std::string GetInfo(int dmaFd, uint32_t width, uint32_t height, uint32_t stride, uint32_t format) const
+    {
+        gbm_import_fd_data data{ dmaFd, width, height, stride, format };
+
+        gbm_bo* bo = gbm_bo_import(_gbmDevice, GBM_BO_IMPORT_FD, &data, 0);
+        if (!bo)
+            return "gbm_bo_import failed";
+
+        uint32_t _format = gbm_bo_get_format(bo);
+        uint64_t _modifier = gbm_bo_get_modifier(bo);
+        uint32_t _width = gbm_bo_get_width(bo);
+        uint32_t _height = gbm_bo_get_height(bo);
+        uint32_t _stride = gbm_bo_get_stride(bo);
+
+        const char* formatName = drmGetFormatName(_format);
+        const char* modifierName = drmGetFormatModifierName(_modifier);
+
+        std::ostringstream oss;
+        oss << "Format: " << (formatName ? formatName : "UNKNOWN")
+            << " (0x" << std::hex << _format << std::dec << ")"
+            << ", Modifier: ";
+
+        if (modifierName)
+            oss << modifierName;
+        else {
+            std::ostringstream modStr;
+            modStr << "0x" << std::hex << _modifier;
+            oss << modStr.str();
+        }
+
+        oss << ", Size: " << _width << "x" << _height
+            << ", Stride: " << _stride;
+
+        gbm_bo_destroy(bo);
+        return oss.str();
+    }
+
+    int _drmFd{ -1 };
+    gbm_device* _gbmDevice{ nullptr };
+    gbm_surface* _surface{ nullptr };
+    EGLDisplay _eglDisplay{ EGL_NO_DISPLAY };
+    EGLContext _eglContext{ EGL_NO_CONTEXT };
+    EGLSurface _eglSurface{ EGL_NO_SURFACE };
+    std::vector<BufferObject*> _buffers;
+
+public:
+    ~SimpleGBMTest() { Cleanup(); }
+
+    bool Initialize(const std::string& device)
+    {
+        _drmFd = open(device.c_str(), O_RDWR | O_CLOEXEC);
+        if (_drmFd < 0) {
+            std::cerr << "Failed to open " << device << ": " << std::strerror(errno) << "\n";
+            return false;
+        }
+        std::cout << "Opened DRM device: " << device << std::endl;
+
+        _gbmDevice = gbm_create_device(_drmFd);
+        if (!_gbmDevice) {
+            std::cerr << "Failed to create GBM device\n";
+            return false;
+        }
+
+        const char* backend = gbm_device_get_backend_name(_gbmDevice);
+        std::cout << "GBM backend: " << (backend ? backend : "unknown") << std::endl;
+
+        // Default: Mesa-style flags (Intel/AMD/others)
+        uint32_t flags = GBM_BO_USE_SCANOUT | GBM_BO_USE_RENDERING;
+
+        // NVIDIA’s GBM implementation requires *no flags*
+        if (backend && strcasecmp(backend, "nvidia") == 0) {
+            flags = 0;
+            std::cout << "Using NVIDIA GBM backend → creating surface with no flags" << std::endl;
+        } else {
+            std::cout << "Using Mesa/other GBM backend → creating surface with SCANOUT | RENDERING" << std::endl;
+        }
+
+        _surface = gbm_surface_create(_gbmDevice, 640, 480, GBM_FORMAT_XRGB8888, flags);
+        if (!_surface) {
+            std::cerr << "Failed to create GBM surface\n";
+            return false;
+        }
+        std::cout << "Created GBM surface.\n";
+
+        return InitEGL();
+    }
+
+    void TestBufferReuse(int iterations)
+    {
+        std::cout << "\n=== Testing Buffer Reuse ===\n";
+
+        for (int i = 0; i < iterations; ++i) {
+            std::cout << "\n--- Iteration " << (i + 1) << " ---\n";
+
+            eglSwapBuffers(_eglDisplay, _eglSurface);
+
+            gbm_bo* bo = gbm_surface_lock_front_buffer(_surface);
+            if (!bo) {
+                std::cerr << "Failed to lock front buffer!\n";
+                break;
+            }
+
+            BufferObject* object = static_cast<BufferObject*>(gbm_bo_get_user_data(bo));
+            bool isReused = true;
+
+            if (!object) {
+                object = new BufferObject(bo);
+                gbm_bo_set_user_data(bo, object, &BufferObject::Destroy);
+                isReused = false;
+            }
+
+            std::cout << "Buffer: " << bo
+                      << " (" << (bo == object->boPtr ? "EQUAL PTR" : "DIFFERENT PTR") << ")"
+                      << " (" << (isReused ? "REUSED" : "NEW") << ")"
+                      << " (" << (object->CheckFd() ? "VALID FD" : "INVALID FD") << ")"
+                      << " (" << (InspectGbmFd(object->fd) ? "VALID BUFFER" : "INVALID BUFFER") << ")"
+                      << " - " << GetInfo(object->fd, gbm_bo_get_width(bo), gbm_bo_get_height(bo), gbm_bo_get_stride(bo), gbm_bo_get_format(bo))
+                      << "\n";
+
+            gbm_surface_release_buffer(_surface, bo);
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        }
+    }
+
+private:
+    bool InitEGL()
+    {
+        _eglDisplay = eglGetPlatformDisplay(EGL_PLATFORM_GBM_KHR, _gbmDevice, nullptr);
+        if (_eglDisplay == EGL_NO_DISPLAY) {
+            std::cerr << "Failed to get EGL display\n";
+            return false;
+        }
+
+        if (!eglInitialize(_eglDisplay, nullptr, nullptr)) {
+            std::cerr << "Failed to initialize EGL\n";
+            return false;
+        }
+
+        const EGLint baseAttribs[] = {
+            EGL_SURFACE_TYPE, EGL_WINDOW_BIT,
+            EGL_RENDERABLE_TYPE, EGL_OPENGL_ES2_BIT,
+            EGL_NONE
+        };
+
+        EGLint numConfigs = 0;
+        if (!eglChooseConfig(_eglDisplay, baseAttribs, nullptr, 0, &numConfigs) || numConfigs == 0) {
+            std::cerr << "eglChooseConfig returned no configs\n";
+            return false;
+        }
+
+        std::vector<EGLConfig> configs(numConfigs);
+        if (!eglChooseConfig(_eglDisplay, baseAttribs, configs.data(), numConfigs, &numConfigs)) {
+            std::cerr << "Failed to get EGL configs\n";
+            return false;
+        }
+
+        EGLConfig config = nullptr;
+        for (int i = 0; i < numConfigs; i++) {
+            EGLint visualId = 0, alphaSize = 0, red = 0, green = 0, blue = 0;
+            eglGetConfigAttrib(_eglDisplay, configs[i], EGL_NATIVE_VISUAL_ID, &visualId);
+            eglGetConfigAttrib(_eglDisplay, configs[i], EGL_ALPHA_SIZE, &alphaSize);
+            eglGetConfigAttrib(_eglDisplay, configs[i], EGL_RED_SIZE, &red);
+            eglGetConfigAttrib(_eglDisplay, configs[i], EGL_GREEN_SIZE, &green);
+            eglGetConfigAttrib(_eglDisplay, configs[i], EGL_BLUE_SIZE, &blue);
+
+            if (visualId == GBM_FORMAT_XRGB8888 && alphaSize == 0) {
+                config = configs[i];
+                std::cout << "Selected EGL config: "
+                          << "R" << red << " G" << green << " B" << blue
+                          << " A" << alphaSize
+                          << " visualId=0x" << std::hex << visualId << std::dec
+                          << std::endl;
+                break;
+            }
+        }
+
+        if (!config) {
+            std::cerr << "No matching EGLConfig found for GBM_FORMAT_XRGB8888\n";
+            return false;
+        }
+
+        const EGLint contextAttribs[] = { EGL_CONTEXT_CLIENT_VERSION, 2, EGL_NONE };
+        _eglContext = eglCreateContext(_eglDisplay, config, EGL_NO_CONTEXT, contextAttribs);
+        if (_eglContext == EGL_NO_CONTEXT) {
+            EGLint error = eglGetError();
+            std::cerr << "Failed to create EGL context: 0x"
+                      << std::hex << error << std::dec << std::endl;
+            return false;
+        }
+
+        _eglSurface = eglCreateWindowSurface(_eglDisplay, config,
+            (EGLNativeWindowType)_surface, nullptr);
+        if (_eglSurface == EGL_NO_SURFACE) {
+            EGLint error = eglGetError();
+            std::cerr << "eglCreateWindowSurface failed with 0x"
+                      << std::hex << error << std::dec << std::endl;
+            return false;
+        }
+
+        if (!eglMakeCurrent(_eglDisplay, _eglSurface, _eglSurface, _eglContext)) {
+            std::cerr << "Failed to make EGL context current\n";
+            return false;
+        }
+
+        std::cout << "EGL initialized successfully\n";
+        return true;
+    }
+
+    void Cleanup()
+    {
+        if (_eglDisplay != EGL_NO_DISPLAY) {
+            eglMakeCurrent(_eglDisplay, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
+            if (_eglSurface != EGL_NO_SURFACE)
+                eglDestroySurface(_eglDisplay, _eglSurface);
+            if (_eglContext != EGL_NO_CONTEXT)
+                eglDestroyContext(_eglDisplay, _eglContext);
+            eglTerminate(_eglDisplay);
+        }
+        if (_surface)
+            gbm_surface_destroy(_surface);
+        if (_gbmDevice)
+            gbm_device_destroy(_gbmDevice);
+        if (_drmFd >= 0)
+            close(_drmFd);
+    }
+};
+
+int main(int argc, char* argv[])
+{
+    std::string device = "/dev/dri/card0";
+    int iterations = 10;
+
+    for (int i = 1; i < argc; ++i) {
+        std::string arg = argv[i];
+        if (arg == "-d" && i + 1 < argc)
+            device = argv[++i];
+        else if (arg == "-i" && i + 1 < argc)
+            iterations = std::atoi(argv[++i]);
+        else if (arg == "-h") {
+            std::cout << "Usage: " << argv[0] << " [-d device] [-i iterations]\n";
+            return 0;
+        }
+    }
+
+    std::cout << "GBM Buffer Reuse Test\nDevice: " << device << "\nIterations: " << iterations << "\n";
+
+    SimpleGBMTest test;
+    if (!test.Initialize(device)) {
+        std::cerr << "Initialization failed!\n";
+        return 1;
+    }
+
+    test.TestBufferReuse(iterations);
+    return 0;
+}

--- a/Source/graphicsbuffer/include/graphicsbuffer/GraphicsBufferType.h
+++ b/Source/graphicsbuffer/include/graphicsbuffer/GraphicsBufferType.h
@@ -282,7 +282,7 @@ namespace Graphics {
             {
                 return (_format);
             }
-            uint32_t Modifier() const
+            uint64_t Modifier() const
             {
                 return (_modifier);
             }

--- a/Source/graphicsbuffer/include/graphicsbuffer/GraphicsBufferType.h
+++ b/Source/graphicsbuffer/include/graphicsbuffer/GraphicsBufferType.h
@@ -162,6 +162,11 @@ namespace Graphics {
             _planes[_count]._stride = stride;
             ++_count;
         }
+        
+        void Modifier(const uint64_t modifier)
+        {
+            _modifier = modifier;
+        }
 
     private:
         uint32_t Stride(const uint8_t index) const
@@ -218,7 +223,7 @@ namespace Graphics {
             // Do not initialize members for now, this constructor is called after a mmap in the
             // placement new operator above. Initializing them now will reset the original values
             // of the buffer metadata.
-            SharedStorageType() { };
+            SharedStorageType() {};
 
             void* operator new(size_t stAllocateBlock, int fd)
             {
@@ -384,6 +389,12 @@ namespace Graphics {
                 pthread_mutex_unlock(&_mutex);
 #endif
                 return (Core::ERROR_NONE);
+            }
+
+        protected:
+            void Modifier(const uint64_t modifier)
+            {
+                _modifier = modifier;
             }
 
         private:

--- a/Source/graphicsbuffer/include/graphicsbuffer/GraphicsBufferType.h
+++ b/Source/graphicsbuffer/include/graphicsbuffer/GraphicsBufferType.h
@@ -162,7 +162,7 @@ namespace Graphics {
             _planes[_count]._stride = stride;
             ++_count;
         }
-        
+
         void Modifier(const uint64_t modifier)
         {
             _modifier = modifier;
@@ -765,7 +765,16 @@ namespace Graphics {
             : SharedBufferType<PLANES>()
         {
         }
-        ~ClientBufferType() override = default;
+
+        ClientBufferType(const uint32_t width, const uint32_t height, const uint32_t format, const uint64_t modifier, const Exchange::IGraphicsBuffer::DataType type)
+            : SharedBufferType<PLANES>(width, height, format, modifier, type)
+        {
+        }
+
+        ~ClientBufferType() override
+        {
+            SharedBufferType<PLANES>::Destroyed();
+        }
 
     public:
         void Load(Core::PrivilegedRequest::Container& descriptors)
@@ -849,7 +858,6 @@ namespace Graphics {
     template <const uint8_t PLANES>
     class ServerBufferType : public SharedBufferType<PLANES> {
     public:
-        ServerBufferType() = delete;
         ServerBufferType(ServerBufferType<PLANES>&&) = delete;
         ServerBufferType(const ServerBufferType<PLANES>&) = delete;
         ServerBufferType<PLANES>& operator=(ServerBufferType<PLANES>&&) = delete;
@@ -863,6 +871,12 @@ namespace Graphics {
             : SharedBufferType<PLANES>(buffer)
         {
         }
+
+        ServerBufferType()
+            : SharedBufferType<PLANES>()
+        {
+        }
+
         ~ServerBufferType() override
         {
             // If we go out of scope, no use for the client
@@ -875,6 +889,12 @@ namespace Graphics {
         {
             SharedBufferType<PLANES>::Load(buffer);
         }
+
+        void Load(Core::PrivilegedRequest::Container& descriptors)
+        {
+            SharedBufferType<PLANES>::Load(descriptors);
+        }
+
         bool Rendered()
         {
             bool requested = true;


### PR DESCRIPTION
- The client is now **fully responsible for buffer allocation**, including pixel format and modifier selection.  
- When ready, the client offers a **DMA-BUF** to the compositor, which is then used to create textures for rendering.  
- Clients can now **manage up to 4 buffers** simultaneously, allowing for improved performance and reduced stalling.  
- Buffer handling has been refactored:  
  - A new **Buffer** object replaces the old `ServerBufferType` association with `Client`.  
  - The client must explicitly request rendering on the correct `ClientBufferType` within its own process space.  
- This change decouples buffer lifecycle management from the compositor, giving the client more control and flexibility.  

related PR:
https://github.com/rdkcentral/ThunderNanoServices/pull/924